### PR TITLE
Fix multi-location load

### DIFF
--- a/gameState.js
+++ b/gameState.js
@@ -9,6 +9,7 @@ const GameState = {
     
     // Location corrente
     currentLocation: null,
+    visitedLocations: [],
     
     // ===== INVENTARIO E FLAG INIZIALI DEL GIOCO =====
     gameInitialState: {
@@ -61,6 +62,24 @@ const GameState = {
     removeFlag(flagName) {
         delete this.flags[flagName];
         this.saveToStorage();
+    },
+
+    // ===== GESTIONE LOCATION =====
+    setCurrentLocation(locationId) {
+        this.currentLocation = locationId;
+        if (!this.visitedLocations.includes(locationId)) {
+            this.visitedLocations.push(locationId);
+        }
+        this.saveToStorage();
+    },
+
+    getDebugInfo() {
+        return {
+            inventory: [...this.inventory],
+            flags: { ...this.flags },
+            currentLocation: this.currentLocation,
+            visitedLocations: [...this.visitedLocations]
+        };
     },
     
     // ===== AGGIORNA INTERFACCIA =====
@@ -174,5 +193,8 @@ window.gameStateDebug = {
     removeItem: (name) => GameState.removeItem(name),
     setFlag: (name) => GameState.setFlag(name),
     hasFlag: (name) => console.log(`Flag ${name}:`, GameState.hasFlag(name)),
-    reset: () => GameState.reset()
+    reset: () => GameState.reset(),
+    showVisited: () => console.log("👣 Visitato:", GameState.visitedLocations),
+    setLocation: (loc) => GameState.setCurrentLocation(loc),
+    debugInfo: () => console.log(GameState.getDebugInfo())
 };

--- a/locationManager.js
+++ b/locationManager.js
@@ -154,8 +154,8 @@ const LocationManager = {
             mergedInventory = []; // GameState gestirà tutto
             
             // Merge flag: location + globali dal GameState
-            Object.keys(window.GameState.flags.data).forEach(flagName => {
-                mergedFlags[flagName] = window.GameState.flags.data[flagName];
+            Object.keys(window.GameState.flags).forEach(flagName => {
+                mergedFlags[flagName] = window.GameState.flags[flagName];
             });
         } else {
             // Fallback al sistema precedente
@@ -277,8 +277,8 @@ const LocationManager = {
         if (window.GameState) {
             console.log("🔗 INTEGRAZIONE GAMESTATE ATTIVA:");
             console.log("📊 Stato GameState:", window.GameState.getDebugInfo());
-            console.log("🎒 Inventario globale:", window.GameState.globalInventory.getAll().map(item => `${item.name} (${item.quantity})`));
-            console.log("🚩 Flag globali attivi:", Object.keys(window.GameState.flags.data).filter(key => window.GameState.flags.data[key]));
+            console.log("🎒 Inventario:", window.GameState.inventory);
+            console.log("🚩 Flag attivi:", Object.keys(window.GameState.flags));
             console.log("👣 Location visitate:", window.GameState.visitedLocations);
         } else {
             console.log("⚠️ GameState non disponibile - usando sistema locale:");

--- a/locations/biblioteca_antica.js
+++ b/locations/biblioteca_antica.js
@@ -1,0 +1,28 @@
+window.currentLocationData = {
+  locationInfo: {
+    id: 'biblioteca_antica',
+    name: 'Biblioteca Antica',
+    description: 'Scaffali colmi di tomi polverosi circondano la stanza.',
+    image: ''
+  },
+  pointsOfInterest: ['Scaffali', 'Leggio'],
+  initialInventory: [],
+  movements: {
+    vaiSud: 'Torna al corridoio del castello.',
+    default: 'Non puoi andare da quella parte.'
+  },
+  interactions: {},
+  effects: {},
+  systemMessages: {
+    verbSelected: 'Hai scelto {verb}.',
+    firstTargetSelected: 'Hai selezionato {target}.',
+    operationCancelled: 'Operazione annullata.',
+    cannotDoThat: 'Non succede nulla.',
+    escapeMessages: {
+      ESCAPE_DOOR: '',
+      ESCAPE_TUNNEL: '',
+      ESCAPE_WINDOW: ''
+    }
+  },
+  flags: {}
+};

--- a/locations/cella_prigioniero.js
+++ b/locations/cella_prigioniero.js
@@ -1,0 +1,32 @@
+window.currentLocationData = {
+  locationInfo: {
+    id: 'cella_prigioniero',
+    name: 'Cella del Prigioniero',
+    description: 'Ti trovi in una piccola cella fredda e umida.',
+    image: ''
+  },
+  pointsOfInterest: ['Porta', 'Pagliericcio'],
+  initialInventory: ['Cucchiaio arrugginito'],
+  movements: {
+    ESCAPE_DOOR: 'Apri con fatica la porta e ti ritrovi nel corridoio.',
+    ESCAPE_TUNNEL: 'Strisci nel tunnel verso il giardino segreto.',
+    ESCAPE_WINDOW: 'Le sbarre ti impediscono di uscire dalla finestra.',
+    default: 'Non puoi andare in quella direzione.'
+  },
+  interactions: {
+    'GUARDA_Porta': 'La porta sembra robusta ma un po\' usurata.'
+  },
+  effects: {},
+  systemMessages: {
+    verbSelected: 'Hai scelto {verb}.',
+    firstTargetSelected: 'Hai selezionato {target}.',
+    operationCancelled: 'Operazione annullata.',
+    cannotDoThat: 'Non succede nulla.',
+    escapeMessages: {
+      ESCAPE_DOOR: 'Esci dalla cella attraverso la porta.',
+      ESCAPE_TUNNEL: 'Ti infili nel tunnel di fuga.',
+      ESCAPE_WINDOW: 'La finestra è troppo stretta.'
+    }
+  },
+  flags: {}
+};

--- a/locations/corridoio_castello.js
+++ b/locations/corridoio_castello.js
@@ -1,0 +1,29 @@
+window.currentLocationData = {
+  locationInfo: {
+    id: 'corridoio_castello',
+    name: 'Corridoio del Castello',
+    description: 'Un lungo corridoio illuminato da torce.',
+    image: ''
+  },
+  pointsOfInterest: ['Porta Nord', 'Porta Est', 'Porta Ovest'],
+  initialInventory: [],
+  movements: {
+    vaiSud: 'Ritorni alla cella del prigioniero.',
+    vaiNord: 'Procedi verso la biblioteca.',
+    default: 'Non puoi andare da quella parte.'
+  },
+  interactions: {},
+  effects: {},
+  systemMessages: {
+    verbSelected: 'Hai scelto {verb}.',
+    firstTargetSelected: 'Hai selezionato {target}.',
+    operationCancelled: 'Operazione annullata.',
+    cannotDoThat: 'Non succede nulla.',
+    escapeMessages: {
+      ESCAPE_DOOR: '',
+      ESCAPE_TUNNEL: '',
+      ESCAPE_WINDOW: ''
+    }
+  },
+  flags: {}
+};

--- a/locations/giardino_segreto.js
+++ b/locations/giardino_segreto.js
@@ -1,0 +1,28 @@
+window.currentLocationData = {
+  locationInfo: {
+    id: 'giardino_segreto',
+    name: 'Giardino Segreto',
+    description: 'Un piccolo giardino nascosto tra le mura.',
+    image: ''
+  },
+  pointsOfInterest: ['Statua', 'Fontana'],
+  initialInventory: [],
+  movements: {
+    entra: 'Rientri nella cella del prigioniero.',
+    default: 'Non puoi andare da quella parte.'
+  },
+  interactions: {},
+  effects: {},
+  systemMessages: {
+    verbSelected: 'Hai scelto {verb}.',
+    firstTargetSelected: 'Hai selezionato {target}.',
+    operationCancelled: 'Operazione annullata.',
+    cannotDoThat: 'Non succede nulla.',
+    escapeMessages: {
+      ESCAPE_DOOR: '',
+      ESCAPE_TUNNEL: '',
+      ESCAPE_WINDOW: ''
+    }
+  },
+  flags: {}
+};


### PR DESCRIPTION
## Summary
- add GameState helpers for multi-location games
- update LocationManager integration with the simplified GameState
- provide minimal sample locations to avoid missing-script errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68428e55a3788326aca914351d5257be