### PR TITLE
Add main menu with multiple save slots

### DIFF
--- a/game.html
+++ b/game.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Adventure GUI Framework</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+  <!-- ===== BOX CENTRALE (contenitore dei 3 box superiori) ===== -->
+  <div class="box-middle" id="SezioneCentrale">
+    <div class="middle-content">
+      <!-- Box sinistro - punti di interesse (popolato dinamicamente) -->
+      <div class="side-box" id="MenuSinistro">
+        <!-- I punti di interesse verranno caricati da data.js o location files -->
+      </div>
+
+      <!-- Box quadrato centrale (ContenutoPrincipale) -->
+      <div class="square" id="ContenutoPrincipale">
+        <!-- L'immagine e contenuto verranno caricati da data.js o location files -->
+        <img id="sceneImage" src="" alt="Scena di gioco" style="max-width: 100%; max-height: 100%; object-fit: contain; display: none;" />
+        <div id="defaultContent" style="padding: 2rem; text-align: center; color: #666;">
+          <h2>🎮 Adventure Game</h2>
+          <p>Caricamento in corso...</p>
+          <p><small>Se vedi questo messaggio, verifica che i file di gioco siano caricati correttamente.</small></p>
+        </div>
+      </div>
+
+      <!-- Box destro con inventario (popolato dinamicamente) -->
+      <div class="side-box" id="MenuDestro">
+        <!-- L'inventario verrà caricato da GameState -->
+      </div>
+    </div>
+  </div>
+
+  <!-- ===== BOX PER I MESSAGGI ===== -->
+  <div class="box-text" id="BoxTesto">
+    Benvenuto! Seleziona un'azione per iniziare l'avventura.
+  </div>
+
+  <!-- ===== BOX INFERIORE FISSATO IN BASSO ===== -->
+  <div class="box-bottom" id="PièDiPagina">
+    <div class="action-panel">
+      <!-- Gruppo Movimento (Sinistra) -->
+      <div class="button-group" id="movementGroup" data-label="MOVIMENTO">
+        <button id="vaiNord">NORD</button>
+        <button id="vaiSud">SUD</button>
+        <button id="vaiEst">EST</button>
+        <button id="vaiOvest">OVEST</button>
+        <button id="sali">SALI</button>
+        <button id="scendi">SCENDI</button>
+        <button id="entra">ENTRA</button>
+        <button id="esci">ESCI</button>
+      </div>
+      
+      <!-- Gruppo Interazioni (Centro) -->
+      <div class="button-group" id="interactionGroup" data-label="INTERAZIONI">
+        <button id="prendi">PRENDI</button>
+        <button id="guarda">GUARDA</button>
+        <button id="parla">PARLA</button>
+        <button id="usaButton">USA</button>
+        <button id="salta">SALTA</button>
+        <button id="leggi">LEGGI</button>
+        <button id="sposta">SPOSTA</button>
+        <button id="indossa">INDOSSA</button>
+        <button id="spingi">SPINGI</button>
+        <button id="tira">TIRA</button>
+        <!-- Pulsante "X" speciale -->
+        <button id="cancelButton" class="hidden">X</button>
+      </div>
+      
+      <!-- Gruppo Futuro (Destra) -->
+      <div class="button-group" id="futureGroup" data-label="COMANDI SPECIALI">
+        <!-- Spazio per futuri pulsanti -->
+        <div style="color: #999; font-style: italic; text-align: center; padding: 1vh; font-size: 1.5vh;">
+          Spazio per<br>futuri comandi
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Database oggetti -->
+  <script src="items.js"></script>
+  
+  <!-- Sistema centrale di gestione stato (semplificato) -->
+  <script src="gameState.js"></script>
+  
+  <!-- MODALITÀ DI GIOCO: Scegli UNA delle opzioni sottostanti -->
+  
+  <!-- OPZIONE 1: Gioco singola location -->
+  <!-- <script src="data.js"></script> -->
+  
+  <!-- OPZIONE 2: Gioco multi-location (commenta data.js sopra e decommenta sotto) -->
+  <script src="locationManager.js"></script>
+  
+  <script src="script.js"></script>
+</body>
+</html>

--- a/gameState.js
+++ b/gameState.js
@@ -10,6 +10,14 @@ const GameState = {
     // Location corrente
     currentLocation: null,
     visitedLocations: [],
+
+    // Slot di salvataggio corrente
+    saveSlot: 'slot1',
+
+    // Chiave di archiviazione basata sullo slot
+    get storageKey() {
+        return `adventureGameSave_${this.saveSlot}`;
+    },
     
     // ===== INVENTARIO E FLAG INIZIALI DEL GIOCO =====
     gameInitialState: {
@@ -81,6 +89,11 @@ const GameState = {
             visitedLocations: [...this.visitedLocations]
         };
     },
+
+    setSaveSlot(slot) {
+        this.saveSlot = slot;
+        localStorage.setItem('currentSaveSlot', this.saveSlot);
+    },
     
     // ===== AGGIORNA INTERFACCIA =====
     updateInventoryInterface() {
@@ -109,7 +122,7 @@ const GameState = {
         };
         
         try {
-            localStorage.setItem('adventureGameSave', JSON.stringify(saveData));
+            localStorage.setItem(this.storageKey, JSON.stringify(saveData));
         } catch (error) {
             console.error("❌ Errore salvataggio:", error);
         }
@@ -117,7 +130,7 @@ const GameState = {
     
     loadFromStorage() {
         try {
-            const saveData = localStorage.getItem('adventureGameSave');
+            const saveData = localStorage.getItem(this.storageKey);
             if (saveData) {
                 const data = JSON.parse(saveData);
                 this.inventory = data.inventory || [];
@@ -133,7 +146,16 @@ const GameState = {
     },
     
     // ===== INIZIALIZZAZIONE =====
-    initialize() {
+    initialize(slot) {
+        if (slot) {
+            this.saveSlot = slot;
+        } else {
+            const storedSlot = localStorage.getItem('currentSaveSlot');
+            this.saveSlot = storedSlot || this.saveSlot;
+        }
+
+        localStorage.setItem('currentSaveSlot', this.saveSlot);
+
         const loaded = this.loadFromStorage();
         
         if (!loaded) {
@@ -167,7 +189,7 @@ const GameState = {
         this.inventory = [];
         this.flags = {};
         this.currentLocation = null;
-        localStorage.removeItem('adventureGameSave');
+        localStorage.removeItem(this.storageKey);
         this.updateInventoryInterface();
         
         // Riapplica stato iniziale

--- a/index.html
+++ b/index.html
@@ -1,99 +1,16 @@
 <!DOCTYPE html>
 <html lang="it">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Adventure GUI Framework</title>
-  <link rel="stylesheet" href="styles.css">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Adventure Game - Menu</title>
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-
-  <!-- ===== BOX CENTRALE (contenitore dei 3 box superiori) ===== -->
-  <div class="box-middle" id="SezioneCentrale">
-    <div class="middle-content">
-      <!-- Box sinistro - punti di interesse (popolato dinamicamente) -->
-      <div class="side-box" id="MenuSinistro">
-        <!-- I punti di interesse verranno caricati da data.js o location files -->
-      </div>
-
-      <!-- Box quadrato centrale (ContenutoPrincipale) -->
-      <div class="square" id="ContenutoPrincipale">
-        <!-- L'immagine e contenuto verranno caricati da data.js o location files -->
-        <img id="sceneImage" src="" alt="Scena di gioco" style="max-width: 100%; max-height: 100%; object-fit: contain; display: none;" />
-        <div id="defaultContent" style="padding: 2rem; text-align: center; color: #666;">
-          <h2>🎮 Adventure Game</h2>
-          <p>Caricamento in corso...</p>
-          <p><small>Se vedi questo messaggio, verifica che i file di gioco siano caricati correttamente.</small></p>
-        </div>
-      </div>
-
-      <!-- Box destro con inventario (popolato dinamicamente) -->
-      <div class="side-box" id="MenuDestro">
-        <!-- L'inventario verrà caricato da GameState -->
-      </div>
+    <div id="mainMenu" class="menu-container">
+        <h1>Adventure Game</h1>
+        <div id="slotContainer"></div>
     </div>
-  </div>
-
-  <!-- ===== BOX PER I MESSAGGI ===== -->
-  <div class="box-text" id="BoxTesto">
-    Benvenuto! Seleziona un'azione per iniziare l'avventura.
-  </div>
-
-  <!-- ===== BOX INFERIORE FISSATO IN BASSO ===== -->
-  <div class="box-bottom" id="PièDiPagina">
-    <div class="action-panel">
-      <!-- Gruppo Movimento (Sinistra) -->
-      <div class="button-group" id="movementGroup" data-label="MOVIMENTO">
-        <button id="vaiNord">NORD</button>
-        <button id="vaiSud">SUD</button>
-        <button id="vaiEst">EST</button>
-        <button id="vaiOvest">OVEST</button>
-        <button id="sali">SALI</button>
-        <button id="scendi">SCENDI</button>
-        <button id="entra">ENTRA</button>
-        <button id="esci">ESCI</button>
-      </div>
-      
-      <!-- Gruppo Interazioni (Centro) -->
-      <div class="button-group" id="interactionGroup" data-label="INTERAZIONI">
-        <button id="prendi">PRENDI</button>
-        <button id="guarda">GUARDA</button>
-        <button id="parla">PARLA</button>
-        <button id="usaButton">USA</button>
-        <button id="salta">SALTA</button>
-        <button id="leggi">LEGGI</button>
-        <button id="sposta">SPOSTA</button>
-        <button id="indossa">INDOSSA</button>
-        <button id="spingi">SPINGI</button>
-        <button id="tira">TIRA</button>
-        <!-- Pulsante "X" speciale -->
-        <button id="cancelButton" class="hidden">X</button>
-      </div>
-      
-      <!-- Gruppo Futuro (Destra) -->
-      <div class="button-group" id="futureGroup" data-label="COMANDI SPECIALI">
-        <!-- Spazio per futuri pulsanti -->
-        <div style="color: #999; font-style: italic; text-align: center; padding: 1vh; font-size: 1.5vh;">
-          Spazio per<br>futuri comandi
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Database oggetti -->
-  <script src="items.js"></script>
-  
-  <!-- Sistema centrale di gestione stato (semplificato) -->
-  <script src="gameState.js"></script>
-  
-  <!-- MODALITÀ DI GIOCO: Scegli UNA delle opzioni sottostanti -->
-  
-  <!-- OPZIONE 1: Gioco singola location -->
-  <!-- <script src="data.js"></script> -->
-  
-  <!-- OPZIONE 2: Gioco multi-location (commenta data.js sopra e decommenta sotto) -->
-  <script src="locationManager.js"></script>
-  
-  <script src="script.js"></script>
+    <script src="menu.js"></script>
 </body>
 </html>

--- a/menu.js
+++ b/menu.js
@@ -1,0 +1,37 @@
+(function() {
+    const slotContainer = document.getElementById('slotContainer');
+    const slots = ['slot1', 'slot2', 'slot3'];
+
+    function createSlotEntry(slot, index) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'slot-entry';
+        const label = document.createElement('span');
+        label.textContent = `Slot ${index + 1}`;
+        wrapper.appendChild(label);
+
+        const key = `adventureGameSave_${slot}`;
+        const hasSave = !!localStorage.getItem(key);
+
+        const loadBtn = document.createElement('button');
+        loadBtn.textContent = 'Carica';
+        loadBtn.disabled = !hasSave;
+        loadBtn.addEventListener('click', () => {
+            localStorage.setItem('currentSaveSlot', slot);
+            window.location.href = 'game.html';
+        });
+        wrapper.appendChild(loadBtn);
+
+        const newBtn = document.createElement('button');
+        newBtn.textContent = 'Nuova Partita';
+        newBtn.addEventListener('click', () => {
+            localStorage.setItem('currentSaveSlot', slot);
+            localStorage.removeItem(key);
+            window.location.href = 'game.html';
+        });
+        wrapper.appendChild(newBtn);
+
+        slotContainer.appendChild(wrapper);
+    }
+
+    slots.forEach((slot, idx) => createSlotEntry(slot, idx));
+})();

--- a/styles.css
+++ b/styles.css
@@ -307,3 +307,20 @@ body {
 #cancelButton.hidden {
   display: none;
 }
+
+/* ====== MENU PRINCIPALE ====== */
+.menu-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  gap: 1rem;
+}
+
+.slot-entry {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}


### PR DESCRIPTION
## Summary
- create a new **index.html** as main menu
- keep the old game interface in **game.html**
- support save slots in GameState
- add menu logic in **menu.js**
- style the menu via **styles.css**

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68429fd108b4832686e168c9a282ae09