### PR TITLE
Improve main menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,21 @@
 <body>
     <div id="mainMenu" class="menu-container">
         <h1>Adventure Game</h1>
-        <div id="slotContainer"></div>
+        <div class="menu-buttons">
+            <button id="newGameBtn">Nuova Partita</button>
+            <button id="loadGameBtn">Carica Partita</button>
+            <button id="optionsBtn">Opzioni</button>
+            <button id="creditsBtn">Credits</button>
+            <button id="quitBtn">Esci dal Gioco</button>
+        </div>
     </div>
+
+    <div id="loadScreen" class="menu-container" style="display:none;">
+        <h1>Carica Partita</h1>
+        <div id="slotGrid" class="slot-grid"></div>
+        <button id="backBtn">Indietro</button>
+    </div>
+
     <script src="menu.js"></script>
 </body>
 </html>

--- a/menu.js
+++ b/menu.js
@@ -1,37 +1,77 @@
 (function() {
-    const slotContainer = document.getElementById('slotContainer');
-    const slots = ['slot1', 'slot2', 'slot3'];
+    const mainMenu = document.getElementById('mainMenu');
+    const loadScreen = document.getElementById('loadScreen');
+    const slotGrid = document.getElementById('slotGrid');
 
-    function createSlotEntry(slot, index) {
-        const wrapper = document.createElement('div');
-        wrapper.className = 'slot-entry';
-        const label = document.createElement('span');
-        label.textContent = `Slot ${index + 1}`;
-        wrapper.appendChild(label);
+    const newGameBtn = document.getElementById('newGameBtn');
+    const loadGameBtn = document.getElementById('loadGameBtn');
+    const backBtn = document.getElementById('backBtn');
 
-        const key = `adventureGameSave_${slot}`;
-        const hasSave = !!localStorage.getItem(key);
+    const locationNames = {
+        'cella_prigioniero': 'Cella del Prigioniero',
+        'corridoio_castello': 'Corridoio del Castello',
+        'biblioteca_antica': 'Biblioteca Antica',
+        'giardino_segreto': 'Giardino Segreto'
+    };
 
-        const loadBtn = document.createElement('button');
-        loadBtn.textContent = 'Carica';
-        loadBtn.disabled = !hasSave;
-        loadBtn.addEventListener('click', () => {
-            localStorage.setItem('currentSaveSlot', slot);
-            window.location.href = 'game.html';
-        });
-        wrapper.appendChild(loadBtn);
+    const slots = Array.from({length: 9}, (_, i) => `slot${i + 1}`);
 
-        const newBtn = document.createElement('button');
-        newBtn.textContent = 'Nuova Partita';
-        newBtn.addEventListener('click', () => {
-            localStorage.setItem('currentSaveSlot', slot);
-            localStorage.removeItem(key);
-            window.location.href = 'game.html';
-        });
-        wrapper.appendChild(newBtn);
-
-        slotContainer.appendChild(wrapper);
+    function startNewGame() {
+        const slot = 'slot1';
+        localStorage.setItem('currentSaveSlot', slot);
+        localStorage.removeItem(`adventureGameSave_${slot}`);
+        window.location.href = 'game.html';
     }
 
-    slots.forEach((slot, idx) => createSlotEntry(slot, idx));
+    function showMainMenu() {
+        loadScreen.style.display = 'none';
+        mainMenu.style.display = 'flex';
+    }
+
+    function showLoadScreen() {
+        slotGrid.innerHTML = '';
+        slots.forEach((slot, index) => {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'slot-entry';
+
+            const label = document.createElement('div');
+            label.textContent = `Slot ${index + 1}`;
+            wrapper.appendChild(label);
+
+            const key = `adventureGameSave_${slot}`;
+            const saveData = localStorage.getItem(key);
+            let summary = 'Vuoto';
+            if (saveData) {
+                try {
+                    const data = JSON.parse(saveData);
+                    const locName = locationNames[data.currentLocation] || data.currentLocation || 'Sconosciuto';
+                    summary = `Posizione: ${locName}`;
+                } catch (e) {
+                    summary = 'Dati non validi';
+                }
+            }
+
+            const info = document.createElement('div');
+            info.textContent = summary;
+            wrapper.appendChild(info);
+
+            const loadBtn = document.createElement('button');
+            loadBtn.textContent = 'Carica';
+            loadBtn.disabled = !saveData;
+            loadBtn.addEventListener('click', () => {
+                localStorage.setItem('currentSaveSlot', slot);
+                window.location.href = 'game.html';
+            });
+            wrapper.appendChild(loadBtn);
+
+            slotGrid.appendChild(wrapper);
+        });
+
+        mainMenu.style.display = 'none';
+        loadScreen.style.display = 'flex';
+    }
+
+    newGameBtn.addEventListener('click', startNewGame);
+    loadGameBtn.addEventListener('click', showLoadScreen);
+    backBtn.addEventListener('click', showMainMenu);
 })();

--- a/styles.css
+++ b/styles.css
@@ -318,9 +318,25 @@ body {
   gap: 1rem;
 }
 
-.slot-entry {
+.menu-buttons {
   display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.slot-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  width: 80%;
+  max-width: 600px;
+}
+
+.slot-entry {
+  border: 1px solid #333;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
   align-items: center;
   gap: 0.5rem;
-  margin: 0.5rem 0;
 }


### PR DESCRIPTION
## Summary
- add vertical buttons to the main menu
- implement load-game screen with 9 save slots
- style grid layout for save slots

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6842c51dab4c832691e91aa246682f5a