### PR TITLE
Add main menu and audio controls

### DIFF
--- a/game.html
+++ b/game.html
@@ -72,10 +72,9 @@
       
       <!-- Gruppo Futuro (Destra) -->
       <div class="button-group" id="futureGroup" data-label="COMANDI SPECIALI">
-        <!-- Spazio per futuri pulsanti -->
-        <div style="color: #999; font-style: italic; text-align: center; padding: 1vh; font-size: 1.5vh;">
-          Spazio per<br>futuri comandi
-        </div>
+        <button id="mainMenuBtn">MAIN MENU</button>
+        <button id="audioToggle" aria-label="Audio">🔊</button>
+        <input type="range" id="volumeSlider" min="0" max="100" value="100">
       </div>
     </div>
   </div>

--- a/script.js
+++ b/script.js
@@ -25,9 +25,17 @@
   const movementButtons = document.querySelectorAll('#movementGroup button');
   
   // Pulsanti di interazione (richiedono target)
-  const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton, 
-                             saltaButton, leggiButton, spostaButton, indossaButton, 
+const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
+                             saltaButton, leggiButton, spostaButton, indossaButton,
                              spingiButton, tiraButton];
+
+  // Pulsanti speciali
+  const mainMenuButton = document.getElementById('mainMenuBtn');
+  const audioToggleButton = document.getElementById('audioToggle');
+  const volumeSlider = document.getElementById('volumeSlider');
+
+  let audioEnabled = true;
+  let volumeLevel = 1.0;
 
   let currentVerb = null;     // Verbo selezionato (e.g. "USA", "GUARDA")
   let useFirstTarget = null;  // Primo oggetto scelto quando currentVerb === 'USA'
@@ -227,6 +235,28 @@
       btn.classList.remove('selected');
     });
     selectedTargets = [];
+  }
+
+  // Aggiorna volume su tutti gli elementi audio
+  function setGlobalVolume(level) {
+    const audios = document.querySelectorAll('audio');
+    audios.forEach(a => {
+      try {
+        a.volume = level;
+      } catch (e) {}
+    });
+    volumeLevel = level;
+  }
+
+  function updateAudioUI() {
+    if (!audioToggleButton || !volumeSlider) return;
+    audioToggleButton.textContent = audioEnabled ? '🔊' : '🔇';
+    volumeSlider.disabled = !audioEnabled;
+    if (audioEnabled) {
+      setGlobalVolume(volumeSlider.value / 100);
+    } else {
+      setGlobalVolume(0);
+    }
   }
 
   // Gestione per i pulsanti di movimento (azioni immediate o cambio location)
@@ -597,6 +627,29 @@
   interactionButtons.forEach(btn => {
     btn.addEventListener('click', onVerbClick);
   });
+
+  if (mainMenuButton) {
+    mainMenuButton.addEventListener('click', () => {
+      window.location.href = 'index.html';
+    });
+  }
+
+  if (audioToggleButton) {
+    audioToggleButton.addEventListener('click', () => {
+      audioEnabled = !audioEnabled;
+      updateAudioUI();
+    });
+  }
+
+  if (volumeSlider) {
+    volumeSlider.addEventListener('input', () => {
+      if (audioEnabled) {
+        setGlobalVolume(volumeSlider.value / 100);
+      }
+    });
+  }
+
+  updateAudioUI();
 
   // Assegno i listener al popup di inventario (destra) e POI (sinistra)
   function updateInventoryListeners() {

--- a/styles.css
+++ b/styles.css
@@ -340,3 +340,8 @@ body {
   align-items: center;
   gap: 0.5rem;
 }
+
+/* Slider volume nel gruppo comandi speciali */
+#volumeSlider {
+  width: 80px;
+}


### PR DESCRIPTION
## Summary
- add a new "MAIN MENU" button and audio controls in the special commands group
- style the volume slider
- implement JS logic for returning to main menu and handling audio toggle/volume

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842ca7e726883269a9828762436e695