### PR TITLE
Enhance save slot info

### DIFF
--- a/gameState.js
+++ b/gameState.js
@@ -11,6 +11,10 @@ const GameState = {
     currentLocation: null,
     visitedLocations: [],
 
+    // Informazioni sul salvataggio
+    savedAt: null,
+    locationName: null,
+
     // Slot di salvataggio corrente
     saveSlot: 'slot1',
 
@@ -118,8 +122,14 @@ const GameState = {
         const saveData = {
             inventory: this.inventory,
             flags: this.flags,
-            currentLocation: this.currentLocation
+            currentLocation: this.currentLocation,
+            locationName: window.LocationManager?.locationConfig?.[this.currentLocation]?.name || this.locationName || this.currentLocation,
+            savedAt: new Date().toISOString()
         };
+
+        // Aggiorna proprietà locali
+        this.savedAt = saveData.savedAt;
+        this.locationName = saveData.locationName;
         
         try {
             localStorage.setItem(this.storageKey, JSON.stringify(saveData));
@@ -136,6 +146,8 @@ const GameState = {
                 this.inventory = data.inventory || [];
                 this.flags = data.flags || {};
                 this.currentLocation = data.currentLocation || null;
+                this.locationName = data.locationName || null;
+                this.savedAt = data.savedAt || null;
                 console.log("📂 Stato caricato dal salvataggio");
                 return true;
             }

--- a/menu.js
+++ b/menu.js
@@ -44,8 +44,9 @@
             if (saveData) {
                 try {
                     const data = JSON.parse(saveData);
-                    const locName = locationNames[data.currentLocation] || data.currentLocation || 'Sconosciuto';
-                    summary = `Posizione: ${locName}`;
+                    const locName = data.locationName || locationNames[data.currentLocation] || data.currentLocation || 'Sconosciuto';
+                    const time = data.savedAt ? new Date(data.savedAt).toLocaleString() : '';
+                    summary = `Posizione: ${locName}` + (time ? ` - ${time}` : '');
                 } catch (e) {
                     summary = 'Dati non validi';
                 }


### PR DESCRIPTION
## Summary
- add savedAt and locationName fields to GameState
- persist new metadata when saving and restore on load
- display location and timestamp on menu load screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842d22aed748326a5915017aae7ad13