### PR TITLE
Style menu layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
 </head>
 <body>
     <div id="mainMenu" class="menu-container">
-        <h1>Adventure Game</h1>
         <div class="menu-buttons">
+            <h1>Adventure Game</h1>
             <button id="newGameBtn">Nuova Partita</button>
             <button id="loadGameBtn">Carica Partita</button>
             <button id="optionsBtn">Opzioni</button>
@@ -19,9 +19,11 @@
     </div>
 
     <div id="loadScreen" class="menu-container" style="display:none;">
-        <h1>Carica Partita</h1>
-        <div id="slotGrid" class="slot-grid"></div>
-        <button id="backBtn">Indietro</button>
+        <div class="menu-buttons">
+            <h1>Carica Partita</h1>
+            <div id="slotGrid" class="slot-grid"></div>
+            <button id="backBtn">Indietro</button>
+        </div>
     </div>
 
     <script src="menu.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -55,6 +55,32 @@ body::before {
   z-index: 1000;
 }
 
+/* ============================
+   MENU PRINCIPALE
+   ============================ */
+.menu-container {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.menu-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5vh;
+  padding: 2vh 3vw;
+  border: 2px solid #00ffff;
+  border-radius: 8px;
+  background:
+    linear-gradient(145deg, rgba(0, 0, 0, 0.9) 0%, rgba(10, 10, 30, 0.95) 100%);
+  backdrop-filter: blur(10px);
+  box-shadow:
+    0 0 20px rgba(0, 255, 255, 0.3),
+    inset 0 1px 0 rgba(0, 255, 255, 0.2);
+  text-align: center;
+}
+
 /* ======================================================
    CONTAINER DEI TRE BOX SUPERIORI (".box-middle")
    ====================================================== */
@@ -393,7 +419,8 @@ body::before {
   margin-top: 1.5vh;
 }
 
-.action-panel button {
+.action-panel button,
+.menu-buttons button {
   padding: 1vh 1.5vw;
   font-size: 1.6vh;
   font-family: 'Rajdhani', monospace;
@@ -627,7 +654,8 @@ button:not(.selected):hover {
     letter-spacing: 1px;
   }
   
-  .action-panel button {
+  .action-panel button,
+  .menu-buttons button {
     font-size: 1.4vh;
     padding: 0.8vh 1.2vw;
   }


### PR DESCRIPTION
## Summary
- center the menu page
- reuse neon button styles for menu buttons

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_6842d22cd5c48326a9498ec7a2e7369e