### PR TITLE
Add save slot grid layout

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -57,6 +57,7 @@
 
             const loadBtn = document.createElement('button');
             loadBtn.textContent = 'Carica';
+            loadBtn.className = 'inventory-button';
             loadBtn.disabled = !saveData;
             loadBtn.addEventListener('click', () => {
                 localStorage.setItem('currentSaveSlot', slot);

--- a/styles.css
+++ b/styles.css
@@ -636,3 +636,31 @@ button:not(.selected):hover {
     font-size: 1.4vh;
   }
 }
+
+/* ============================
+   SAVE SLOT GRID (Load Menu)
+   ============================ */
+.slot-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2vh;
+  width: 100%;
+  margin: 2vh 0;
+}
+
+.slot-entry {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1vh;
+  min-height: 15vh;
+  background: linear-gradient(145deg, rgba(0, 0, 0, 0.8) 0%, rgba(10, 10, 30, 0.9) 100%);
+  border: 2px solid #00ffff;
+  border-radius: 8px;
+  color: #ffffff;
+  box-shadow:
+    0 0 15px rgba(0, 255, 255, 0.4),
+    inset 0 1px 0 rgba(0, 255, 255, 0.2);
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- style a 3x3 grid of save slots with neon look
- hook up load buttons with game button style

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842d22bef608326981b6979bdc560c6