### PR TITLE
Implement save slot selection for new game

### DIFF
--- a/gameState.js
+++ b/gameState.js
@@ -14,6 +14,7 @@ const GameState = {
     // Informazioni sul salvataggio
     savedAt: null,
     locationName: null,
+    saveName: '',
 
     // Slot di salvataggio corrente
     saveSlot: 'slot1',
@@ -124,7 +125,8 @@ const GameState = {
             flags: this.flags,
             currentLocation: this.currentLocation,
             locationName: window.LocationManager?.locationConfig?.[this.currentLocation]?.name || this.locationName || this.currentLocation,
-            savedAt: new Date().toISOString()
+            savedAt: new Date().toISOString(),
+            saveName: this.saveName
         };
 
         // Aggiorna proprietà locali
@@ -148,6 +150,7 @@ const GameState = {
                 this.currentLocation = data.currentLocation || null;
                 this.locationName = data.locationName || null;
                 this.savedAt = data.savedAt || null;
+                this.saveName = data.saveName || this.saveName;
                 console.log("📂 Stato caricato dal salvataggio");
                 return true;
             }
@@ -169,11 +172,18 @@ const GameState = {
         localStorage.setItem('currentSaveSlot', this.saveSlot);
 
         const loaded = this.loadFromStorage();
-        
+
+        const pendingName = localStorage.getItem('pendingSaveName');
+        if (pendingName) {
+            this.saveName = pendingName;
+            localStorage.removeItem('pendingSaveName');
+        }
+
         if (!loaded) {
             // Primo avvio: imposta stato iniziale
             console.log("🎮 Primo avvio - Impostazione stato iniziale");
             this.setupInitialGameState();
+            this.saveToStorage();
         }
         
         console.log("🎮 GameState inizializzato");

--- a/index.html
+++ b/index.html
@@ -26,6 +26,16 @@
         </div>
     </div>
 
+    <div id="newGameScreen" class="menu-container" style="display:none;">
+        <div class="menu-buttons">
+            <h1>Nuova Partita</h1>
+            <input id="saveNameInput" class="save-name-input" type="text" placeholder="Nome salvataggio" />
+            <div id="newSlotGrid" class="slot-grid"></div>
+            <button id="createGameBtn">Avvia</button>
+            <button id="cancelNewGameBtn">Annulla</button>
+        </div>
+    </div>
+
     <script src="menu.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -723,3 +723,20 @@ button:not(.selected):hover {
     0 0 15px rgba(255, 0, 255, 0.7),
     inset 0 1px 0 rgba(255, 0, 255, 0.4);
 }
+
+.slot-entry.selected-slot {
+  border-color: #ffff00;
+  box-shadow:
+    0 0 15px rgba(255, 255, 0, 0.7),
+    inset 0 1px 0 rgba(255, 255, 0, 0.4);
+}
+
+.save-name-input {
+  padding: 1vh;
+  font-size: 2vh;
+  border: 2px solid #00ffff;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.8);
+  color: #ffffff;
+  margin-bottom: 2vh;
+}


### PR DESCRIPTION
## Summary
- add screen to name a new save and choose a slot
- style selected slots and input field
- extend GameState with saveName support
- update load screen to show save name, location and timestamp

## Testing
- `node --check menu.js`
- `node --check gameState.js`

------
https://chatgpt.com/codex/tasks/task_e_6842dfa1c3a08326a2d74cf0e3299b50