### PR TITLE
Implement cutscene overlay

### DIFF
--- a/cutsceneManager.js
+++ b/cutsceneManager.js
@@ -1,0 +1,74 @@
+// Sistema di gestione cutscene semplice
+const CutsceneManager = {
+    currentCutsceneId: null,
+    cutscenes: {},
+
+    // Configurazione delle cutscene disponibili
+    cutsceneConfig: {
+        'intro': { file: 'cutscenes/intro.js' }
+    },
+
+    async loadCutscene(id) {
+        if (this.cutscenes[id]) {
+            return this.cutscenes[id];
+        }
+        const config = this.cutsceneConfig[id];
+        if (!config) throw new Error(`Cutscene non trovata: ${id}`);
+        await this.loadScript(config.file);
+        if (!window.currentCutsceneData) throw new Error(`Il file ${config.file} non ha impostato currentCutsceneData`);
+        this.cutscenes[id] = { ...window.currentCutsceneData, id };
+        window.currentCutsceneData = null;
+        return this.cutscenes[id];
+    },
+
+    loadScript(src) {
+        return new Promise((resolve, reject) => {
+            const existing = document.querySelector(`script[src="${src}"]`);
+            if (existing) existing.remove();
+            const script = document.createElement('script');
+            script.src = src;
+            script.onload = resolve;
+            script.onerror = reject;
+            document.head.appendChild(script);
+        });
+    },
+
+    async playCutscene(id) {
+        const data = await this.loadCutscene(id);
+        this.currentCutsceneId = id;
+        if (window.showCutscene) {
+            window.showCutscene(data);
+        }
+    }
+};
+
+function showCutscene(data) {
+    const overlay = document.getElementById('cutsceneOverlay');
+    const img = document.getElementById('cutsceneImage');
+    const textElem = document.getElementById('cutsceneText');
+    const btn = document.getElementById('cutsceneContinueBtn');
+    if (!overlay || !btn) return;
+    if (img) {
+        img.src = data.image || '';
+    }
+    if (textElem) {
+        textElem.textContent = data.text || '';
+    }
+    overlay.style.display = 'flex';
+    btn.onclick = async () => {
+        overlay.style.display = 'none';
+        if (data.nextLocation && window.LocationManager) {
+            await window.LocationManager.changeLocation(data.nextLocation);
+        }
+    };
+}
+
+// Avvia la cutscene introduttiva all'avvio per test
+document.addEventListener('DOMContentLoaded', () => {
+    if (CutsceneManager.cutsceneConfig['intro']) {
+        CutsceneManager.playCutscene('intro');
+    }
+});
+
+window.CutsceneManager = CutsceneManager;
+window.showCutscene = showCutscene;

--- a/cutscenes/intro.js
+++ b/cutscenes/intro.js
@@ -1,0 +1,6 @@
+window.currentCutsceneData = {
+  id: 'intro',
+  image: 'assets/images/cutscene_intro.jpg',
+  text: 'Il tuo viaggio sta per cominciare. Le tenebre avvolgono il reame mentre tu apri gli occhi nella cella.',
+  nextLocation: 'cella_prigioniero'
+};

--- a/game.html
+++ b/game.html
@@ -79,6 +79,15 @@
     </div>
   </div>
 
+  <!-- ===== CUTSCENE OVERLAY ===== -->
+  <div id="cutsceneOverlay" class="cutscene-overlay" style="display:none;">
+    <div class="cutscene-image">
+      <img id="cutsceneImage" src="" alt="Cutscene" />
+    </div>
+    <div id="cutsceneText" class="cutscene-text"></div>
+    <button id="cutsceneContinueBtn" class="cutscene-button">CONTINUE</button>
+  </div>
+
   <!-- Database oggetti -->
   <script src="items.js"></script>
   
@@ -92,7 +101,8 @@
   
   <!-- OPZIONE 2: Gioco multi-location (commenta data.js sopra e decommenta sotto) -->
   <script src="locationManager.js"></script>
-  
+  <script src="cutsceneManager.js"></script>
+
   <script src="script.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -740,3 +740,74 @@ button:not(.selected):hover {
   color: #ffffff;
   margin-bottom: 2vh;
 }
+
+/* ========================
+   CUTSCENE OVERLAY
+   ======================== */
+.cutscene-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.85);
+  z-index: 2000;
+}
+
+.cutscene-image {
+  height: 60vh;
+  width: calc(60vh * 2);
+  max-width: 90vw;
+  border: 2px solid #00ffff;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow:
+    0 0 20px rgba(0, 255, 255, 0.5),
+    inset 0 1px 0 rgba(0, 255, 255, 0.2);
+  margin-bottom: 2vh;
+}
+
+.cutscene-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cutscene-text {
+  height: 30vh;
+  width: calc(60vh * 2);
+  max-width: 90vw;
+  border: 2px solid #ff006a;
+  border-radius: 6px;
+  padding: 1vh;
+  overflow-y: auto;
+  background:
+    linear-gradient(135deg, rgba(0, 0, 0, 0.95) 0%, rgba(20, 0, 15, 0.98) 100%);
+  color: #ffffff;
+  margin-bottom: 2vh;
+  box-shadow:
+    0 0 15px rgba(255, 0, 106, 0.4),
+    inset 0 1px 0 rgba(255, 0, 106, 0.1);
+  text-shadow: 0 0 3px rgba(0, 255, 255, 0.3);
+  font-family: 'Orbitron', monospace;
+  letter-spacing: 0.5px;
+}
+
+.cutscene-button {
+  padding: 1vh 2vw;
+  font-size: 2vh;
+  font-family: 'Rajdhani', monospace;
+  background: linear-gradient(145deg, rgba(0, 255, 100, 0.95) 0%, rgba(0, 150, 50, 0.9) 100%);
+  border: 2px solid #00ff64;
+  color: #000000;
+  border-radius: 6px;
+  cursor: pointer;
+  box-shadow:
+    0 2px 10px rgba(0, 255, 100, 0.3),
+    inset 0 1px 0 rgba(0, 255, 100, 0.3);
+}
+


### PR DESCRIPTION
## Summary
- add cutscene overlay DOM in `game.html`
- implement `CutsceneManager` to load/play cutscenes
- create an example cutscene data file
- style cutscene overlay with neon punk look

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68430c442a3c83268e297ca677fb694c