### PR TITLE
Add dialogue system with droide NPC

### DIFF
--- a/dialogueManager.js
+++ b/dialogueManager.js
@@ -1,0 +1,52 @@
+// ===== SEMPLICE SISTEMA DI DIALOGHI =====
+const DialogueManager = {
+    dialogues: {},
+    dialogueConfig: {
+        'droide_xc1230': { file: 'dialogues/droide_xc1230.js' }
+    },
+
+    async loadDialogue(id) {
+        if (this.dialogues[id]) {
+            return this.dialogues[id];
+        }
+        const cfg = this.dialogueConfig[id];
+        if (!cfg) throw new Error(`Dialogo non trovato: ${id}`);
+        await this.loadScript(cfg.file);
+        if (!window.currentDialogueData) {
+            throw new Error(`Il file ${cfg.file} non ha impostato currentDialogueData`);
+        }
+        this.dialogues[id] = { ...window.currentDialogueData, id };
+        window.currentDialogueData = null;
+        return this.dialogues[id];
+    },
+
+    loadScript(src) {
+        return new Promise((resolve, reject) => {
+            const existing = document.querySelector(`script[src="${src}"]`);
+            if (existing) existing.remove();
+            const script = document.createElement('script');
+            script.src = src;
+            script.onload = resolve;
+            script.onerror = reject;
+            document.head.appendChild(script);
+        });
+    },
+
+    async playDialogue(id) {
+        const data = await this.loadDialogue(id);
+        if (!window.showDialogue) return;
+        const options = (data.options || []).map(opt => ({
+            text: opt.text,
+            onSelect: () => {
+                setTimeout(() => {
+                    window.showDialogue(data.image || '', opt.response, [
+                        { text: 'Chiudi', onSelect: () => {} }
+                    ]);
+                }, 0);
+            }
+        }));
+        window.showDialogue(data.image || '', data.text, options);
+    }
+};
+
+window.DialogueManager = DialogueManager;

--- a/dialogues/droide_xc1230.js
+++ b/dialogues/droide_xc1230.js
@@ -1,0 +1,11 @@
+window.currentDialogueData = {
+  id: 'droide_xc1230',
+  image: '',
+  text: 'Droide XC-1230, controllo sicurezza: identificarsi',
+  options: [
+    { text: 'Sono il nuovo guardiano', response: 'Accesso negato. Le credenziali non risultano.' },
+    { text: 'Passavo di qui per caso', response: 'Zona riservata. Allontanarsi immediatamente.' },
+    { text: 'Sto cercando l\'uscita', response: 'La via di uscita più vicina è alle tue spalle.' },
+    { text: 'Preferisco non rispondere', response: 'Richiesta incomprensibile.' }
+  ]
+};

--- a/game.html
+++ b/game.html
@@ -113,6 +113,7 @@
   <!-- OPZIONE 2: Gioco multi-location (commenta data.js sopra e decommenta sotto) -->
   <script src="locationManager.js"></script>
   <script src="cutsceneManager.js"></script>
+  <script src="dialogueManager.js"></script>
 
   <script src="script.js"></script>
 </body>

--- a/locations/corridoio_castello.js
+++ b/locations/corridoio_castello.js
@@ -5,14 +5,21 @@ window.currentLocationData = {
     description: 'Un lungo corridoio illuminato da torce.',
     image: ''
   },
-  pointsOfInterest: ['Porta Nord', 'Porta Est', 'Porta Ovest'],
+  pointsOfInterest: ['Porta Nord', 'Porta Est', 'Porta Ovest', 'Droide'],
   initialInventory: [],
   movements: {
     vaiSud: 'Ritorni alla cella del prigioniero.',
     vaiNord: 'Procedi verso la biblioteca.',
     default: 'Non puoi andare da quella parte.'
   },
-  interactions: {},
+  interactions: {
+    'GUARDA_Droide': 'Un droide di sorveglianza dall\'aspetto severo.',
+    'PARLA_Droide': () => {
+      if (window.DialogueManager) {
+        window.DialogueManager.playDialogue('droide_xc1230');
+      }
+    }
+  },
   effects: {},
   systemMessages: {
     verbSelected: 'Hai scelto {verb}.',

--- a/script.js
+++ b/script.js
@@ -446,7 +446,11 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
           }
         }
 
-        showStatus(response);
+        if (typeof response === 'function') {
+          response();
+        } else {
+          showStatus(response);
+        }
         resetVerbState();
         return;
       }
@@ -475,7 +479,11 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
       }
     }
     
-    showStatus(response);
+    if (typeof response === 'function') {
+      response();
+    } else {
+      showStatus(response);
+    }
     resetVerbState();
   }
 


### PR DESCRIPTION
## Summary
- add a simple `DialogueManager` for loading dialogue scripts
- create dialogue data for the droide XC-1230
- hook new droide NPC into `corridoio_castello`
- enable function actions in interactions
- load `dialogueManager.js` in the game page

## Testing
- `node -c script.js`
- `node -c dialogueManager.js`
- `node -c dialogues/droide_xc1230.js`


------
https://chatgpt.com/codex/tasks/task_e_6843159477ac832693df990963ab6b4f