### PR TITLE
Implement background and menu music

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body class="menu-screen">
+    <audio id="menuMusic" src="assets/music/main_menu_theme.mp3" loop></audio>
     <div id="mainMenu" class="menu-container">
         <div class="menu-buttons">
             <h1>Adventure Game</h1>

--- a/locations/corridoio_castello.js
+++ b/locations/corridoio_castello.js
@@ -18,6 +18,11 @@ window.currentLocationData = {
       if (window.DialogueManager) {
         window.DialogueManager.playDialogue('droide_xc1230');
       }
+    },
+    'PARLA_DROIDE': () => {
+      if (window.DialogueManager) {
+        window.DialogueManager.playDialogue('droide_xc1230');
+      }
     }
   },
   effects: {},

--- a/menu.js
+++ b/menu.js
@@ -13,6 +13,13 @@
     const backBtn = document.getElementById('backBtn');
     const quitBtn = document.getElementById('quitBtn');
 
+    const menuMusic = document.getElementById('menuMusic');
+    if (menuMusic) {
+        menuMusic.volume = 0.1;
+        menuMusic.loop = true;
+        menuMusic.play().catch(() => {});
+    }
+
     const locationNames = {
         'cella_prigioniero': 'Cella del Prigioniero',
         'corridoio_castello': 'Corridoio del Castello',

--- a/styles.css
+++ b/styles.css
@@ -754,7 +754,12 @@ button:not(.selected):hover {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  background: rgba(0, 0, 0, 0.85);
+  background:
+    radial-gradient(circle at 20% 80%, rgba(120, 0, 255, 0.08) 0%, transparent 50%),
+    radial-gradient(circle at 80% 20%, rgba(0, 255, 255, 0.08) 0%, transparent 50%),
+    radial-gradient(circle at 40% 40%, rgba(255, 0, 100, 0.03) 0%, transparent 50%),
+    linear-gradient(135deg, #0a0a0a 0%, #1a0a1a 50%, #0a1a1a 100%);
+  background-attachment: fixed;
   z-index: 2000;
 }
 


### PR DESCRIPTION
## Summary
- give cutscene overlay the same gradient as the main menu
- add audio element in index.html and start menu music in JavaScript
- support talk command on DROIDE in the corridor
- include placeholder `main_menu_theme.mp3`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684320493b188326aed0fab1c28b0f5d