### PR TITLE
Fix dialogue overlay and remove extra scroll

### DIFF
--- a/script.js
+++ b/script.js
@@ -777,7 +777,7 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
   window.gameInterface = {
     initializeGame: initializeGame,
     loadScene: loadScene,
-    loadInventory: loadInventory, 
+    loadInventory: loadInventory,
     loadPointsOfInterest: loadPointsOfInterest,
     addToInventory: addToInventory,
     removeFromInventory: removeFromInventory,
@@ -794,6 +794,10 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
     applyEffect: applyEffect,
     isGameReady: isGameReady
   };
+
+  // Rendi accessibili le funzioni di dialogo al gestore dei dialoghi
+  window.showDialogue = showDialogue;
+  window.hideDialogue = hideDialogue;
 
   // Funzioni di utilità per debug (semplificate)
   window.gameDebug = {

--- a/styles.css
+++ b/styles.css
@@ -24,7 +24,7 @@ html, body {
 body {
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
+  overflow-y: hidden;
   overflow-x: hidden;
   padding-bottom: 16vh;
   min-height: 100vh;


### PR DESCRIPTION
## Summary
- prevent extra page scrollbar by hiding body overflow
- expose showDialogue/hideDialogue globally so dialogue interaction works

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68435ed3951083268d91e6ee48803845