### PR TITLE
Improve UI layout and add glitch transitions

### DIFF
--- a/game.html
+++ b/game.html
@@ -13,7 +13,8 @@
     <div class="middle-content">
       <!-- Box sinistro - punti di interesse (popolato dinamicamente) -->
       <div class="side-box" id="MenuSinistro">
-        <!-- I punti di interesse verranno caricati da data.js o location files -->
+        <h3 class="side-title">Points of interest</h3>
+        <div id="PoiList"></div>
       </div>
 
       <!-- Box quadrato centrale (ContenutoPrincipale) -->
@@ -29,18 +30,17 @@
 
       <!-- Box destro con inventario (popolato dinamicamente) -->
       <div class="side-box" id="MenuDestro">
-        <!-- L'inventario verrà caricato da GameState -->
+        <h3 class="side-title">Inventory</h3>
+        <div id="InventoryList"></div>
       </div>
     </div>
   </div>
 
-  <!-- ===== BOX PER I MESSAGGI ===== -->
-  <div class="box-text" id="BoxTesto">
-    Benvenuto! Seleziona un'azione per iniziare l'avventura.
-  </div>
-
-  <!-- ===== BOX INFERIORE FISSATO IN BASSO ===== -->
+  <!-- ===== BOX INFERIORE FLESSIBILE ===== -->
   <div class="box-bottom" id="PièDiPagina">
+    <div class="box-text" id="BoxTesto">
+      Benvenuto! Seleziona un'azione per iniziare l'avventura.
+    </div>
     <div class="action-panel">
       <!-- Gruppo Movimento (Sinistra) -->
       <div class="button-group" id="movementGroup" data-label="MOVIMENTO">
@@ -98,6 +98,8 @@
       <div id="dialogueOptions" class="dialogue-options"></div>
     </div>
   </div>
+
+  <div id="transitionOverlay" class="transition-overlay" style="display:block;"></div>
 
   <!-- Database oggetti -->
   <script src="items.js"></script>

--- a/gameState.js
+++ b/gameState.js
@@ -125,7 +125,7 @@ const GameState = {
     
     // ===== AGGIORNA INTERFACCIA =====
     updateInventoryInterface() {
-        const inventoryContainer = document.getElementById('MenuDestro');
+        const inventoryContainer = document.getElementById('InventoryList');
         if (!inventoryContainer) return;
         
         // Pulisce inventario

--- a/index.html
+++ b/index.html
@@ -37,6 +37,8 @@
         </div>
     </div>
 
+    <div id="transitionOverlay" class="transition-overlay" style="display:none;"></div>
+
     <script src="menu.js"></script>
 </body>
 </html>

--- a/menu.js
+++ b/menu.js
@@ -7,6 +7,7 @@
     const saveNameInput = document.getElementById('saveNameInput');
     const createGameBtn = document.getElementById('createGameBtn');
     const cancelNewGameBtn = document.getElementById('cancelNewGameBtn');
+    const transitionOverlay = document.getElementById('transitionOverlay');
 
     const newGameBtn = document.getElementById('newGameBtn');
     const loadGameBtn = document.getElementById('loadGameBtn');
@@ -52,6 +53,16 @@
             info.textContent = saveData ? 'Occupato' : 'Vuoto';
             wrapper.appendChild(info);
 
+            const selectBtn = document.createElement('button');
+            selectBtn.textContent = 'Seleziona';
+            selectBtn.className = 'inventory-button';
+            selectBtn.addEventListener('click', () => {
+                selectedSlot = slot;
+                Array.from(newSlotGrid.children).forEach(c => c.classList.remove('selected-slot'));
+                wrapper.classList.add('selected-slot');
+            });
+            wrapper.appendChild(selectBtn);
+
             wrapper.addEventListener('click', () => {
                 selectedSlot = slot;
                 Array.from(newSlotGrid.children).forEach(c => c.classList.remove('selected-slot'));
@@ -82,7 +93,8 @@
         localStorage.setItem('pendingSaveName', name);
         localStorage.setItem('startIntroCutscene', 'true');
         localStorage.removeItem(key);
-        window.location.href = 'game.html';
+        if (transitionOverlay) transitionOverlay.style.display = 'block';
+        setTimeout(() => { window.location.href = 'game.html'; }, 300);
     }
 
     function showMainMenu() {
@@ -129,7 +141,8 @@
             loadBtn.disabled = !saveData;
             loadBtn.addEventListener('click', () => {
                 localStorage.setItem('currentSaveSlot', slot);
-                window.location.href = 'game.html';
+                if (transitionOverlay) transitionOverlay.style.display = 'block';
+                setTimeout(() => { window.location.href = 'game.html'; }, 300);
             });
             wrapper.appendChild(loadBtn);
 

--- a/script.js
+++ b/script.js
@@ -2,6 +2,9 @@
   // Elementi DOM principali
   const MenuDestro = document.getElementById('MenuDestro');
   const MenuSinistro = document.getElementById('MenuSinistro');
+  const InventoryList = document.getElementById('InventoryList');
+  const PoiList = document.getElementById('PoiList');
+  const transitionOverlay = document.getElementById('transitionOverlay');
   const BoxTesto = document.getElementById('BoxTesto');
   const ContenutoPrincipale = document.getElementById('ContenutoPrincipale');
   const sceneImage = document.getElementById('sceneImage');
@@ -42,6 +45,14 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
 
   let audioEnabled = true;
   let volumeLevel = 1.0;
+
+  function showTransition() {
+    if (transitionOverlay) transitionOverlay.style.display = 'block';
+  }
+
+  function hideTransition() {
+    if (transitionOverlay) transitionOverlay.style.display = 'none';
+  }
 
   let currentVerb = null;     // Verbo selezionato (e.g. "USA", "GUARDA")
   let useFirstTarget = null;  // Primo oggetto scelto quando currentVerb === 'USA'
@@ -142,7 +153,7 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
       window.GameState.updateInventoryInterface();
     } else {
       // Fallback al sistema locale (se non c'è GameState)
-      MenuDestro.innerHTML = '';
+      InventoryList.innerHTML = '';
       
       if (window.gameData && window.gameData.initialInventory) {
         window.gameData.initialInventory.forEach(item => {
@@ -154,7 +165,7 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
 
   // Carica i punti di interesse
   function loadPointsOfInterest() {
-    MenuSinistro.innerHTML = ''; // Pulisce i POI esistenti
+    PoiList.innerHTML = ''; // Pulisce i POI esistenti
     
     window.gameData.pointsOfInterest.forEach(poi => {
       addPointOfInterest(poi);
@@ -167,12 +178,12 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
     button.className = 'left-button';
     button.textContent = poiName;
     button.addEventListener('click', onTargetClick);
-    MenuSinistro.appendChild(button);
+    PoiList.appendChild(button);
   }
 
   // Rimuove un punto di interesse
   function removePointOfInterest(poiName) {
-    const buttons = MenuSinistro.querySelectorAll('.left-button');
+    const buttons = PoiList.querySelectorAll('.left-button');
     buttons.forEach(btn => {
       if (btn.textContent.trim() === poiName) {
         btn.remove();
@@ -186,7 +197,7 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
       window.GameState.removeItem(itemName);
     } else {
       // Fallback al sistema locale
-      const buttons = MenuDestro.querySelectorAll('.inventory-button');
+      const buttons = InventoryList.querySelectorAll('.inventory-button');
       buttons.forEach(btn => {
         if (btn.textContent.trim() === itemName) {
           btn.remove();
@@ -205,7 +216,7 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
       newButton.className = 'inventory-button';
       newButton.textContent = itemName;
       newButton.addEventListener('click', onTargetClick);
-      MenuDestro.appendChild(newButton);
+      InventoryList.appendChild(newButton);
       updateInventoryListeners();
     }
   }
@@ -674,7 +685,8 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
 
   if (mainMenuButton) {
     mainMenuButton.addEventListener('click', () => {
-      window.location.href = 'index.html';
+      showTransition();
+      setTimeout(() => { window.location.href = 'index.html'; }, 300);
     });
   }
 
@@ -697,7 +709,7 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
 
   // Assegno i listener al popup di inventario (destra) e POI (sinistra)
   function updateInventoryListeners() {
-    const currentInventoryButtons = Array.from(MenuDestro.querySelectorAll('.inventory-button'));
+    const currentInventoryButtons = Array.from(InventoryList.querySelectorAll('.inventory-button'));
     currentInventoryButtons.forEach(btn => {
       // Rimuovi listener esistenti per evitare duplicati
       btn.removeEventListener('click', onTargetClick);
@@ -735,6 +747,7 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
         } else {
           await window.LocationManager.initialize();
         }
+        hideTransition();
       } catch (error) {
         console.error("❌ Errore nell'inizializzazione LocationManager:", error);
         showStatus("❌ Errore nel caricamento del sistema multi-location", true);
@@ -746,6 +759,7 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
       if (!success) {
         showStatus("❌ Errore nell'inizializzazione del gioco singola location", true);
       }
+      hideTransition();
     } else {
       // Nessun dato disponibile
       console.warn("⚠️ Nessun sistema di gioco disponibile");
@@ -765,6 +779,7 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
           <p><small>Apri la console (F12) per maggiori dettagli.</small></p>
         `;
       }
+      hideTransition();
     }
   }
 
@@ -817,7 +832,7 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
       if (window.GameState) {
         console.log("🎒 Inventario:", window.GameState.inventory);
       } else {
-        const items = Array.from(document.querySelectorAll('#MenuDestro .inventory-button'))
+        const items = Array.from(document.querySelectorAll('#InventoryList .inventory-button'))
                           .map(btn => btn.textContent.trim());
         console.log("🎒 Inventario attuale:", items);
       }

--- a/styles.css
+++ b/styles.css
@@ -114,7 +114,7 @@ body::before {
 .box-text {
   position: relative;
   width: 100%;
-  height: 12vh;
+  height: 8vh;
   border: 2px solid #ff006a;
   border-radius: 6px;
   box-sizing: border-box;
@@ -126,7 +126,7 @@ body::before {
   font-size: 1.8vh;
   line-height: 1.4;
   color: #ffffff;
-  margin: 10px 0;
+  margin: 5px 0;
   box-shadow: 
     0 0 15px rgba(255, 0, 106, 0.4),
     inset 0 1px 0 rgba(255, 0, 106, 0.1);
@@ -158,7 +158,7 @@ body::before {
   position: fixed;
   bottom: 0;
   left: 0;
-  height: 16vh;
+  height: 20vh;
   width: 100%;
   border: 2px solid #00ff88;
   border-bottom: none;
@@ -207,6 +207,16 @@ body::before {
   box-shadow: 
     0 0 15px rgba(255, 61, 113, 0.3),
     inset 0 1px 0 rgba(255, 61, 113, 0.1);
+}
+
+.side-title {
+  margin: 0 0 0.5vh 0;
+  font-size: 1.8vh;
+  text-align: center;
+  font-family: 'Orbitron', monospace;
+  text-transform: uppercase;
+  color: #ffffff;
+  text-shadow: 0 0 3px rgba(0, 255, 255, 0.3);
 }
 
 /* Box sinistro - Points of Interest */
@@ -701,8 +711,8 @@ button:not(.selected):hover {
 
 @media (max-height: 600px) {
   .box-middle { height: 60vh; }
-  .box-text   { height: 10vh; }
-  .box-bottom { height: 14vh; }
+  .box-text   { height: 6vh; }
+  .box-bottom { height: 16vh; }
 }
 
 /* ============================
@@ -913,6 +923,30 @@ button:not(.selected):hover {
   box-shadow:
     0 2px 10px rgba(0, 255, 100, 0.3),
     inset 0 1px 0 rgba(0, 255, 100, 0.3);
+}
+
+/* ========================
+   TRANSITION OVERLAY
+   ======================== */
+.transition-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: #000;
+  z-index: 3000;
+  pointer-events: none;
+  animation: glitchAnimation 0.8s steps(2, end) infinite;
+}
+
+@keyframes glitchAnimation {
+  0% { clip-path: inset(0 0 90% 0); opacity: 0.8; }
+  20% { clip-path: inset(10% 0 70% 0); }
+  40% { clip-path: inset(20% 0 60% 0); }
+  60% { clip-path: inset(30% 0 50% 0); }
+  80% { clip-path: inset(40% 0 40% 0); }
+  100% { clip-path: inset(50% 0 30% 0); opacity: 0.8; }
 }
 
 


### PR DESCRIPTION
## Summary
- unify save slot layout for new/load screens
- refactor bottom HUD into a single flexible box
- add titles to the side boxes
- add futuristic glitch transition overlay
- ensure initialization hides the game screen until loaded

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684377c694cc83268a3bc1b99b4d9c4f