### PR TITLE
Update layout with side-by-side text and image boxes

### DIFF
--- a/game.html
+++ b/game.html
@@ -27,6 +27,9 @@
           <p><small>Se vedi questo messaggio, verifica che i file di gioco siano caricati correttamente.</small></p>
         </div>
       </div>
+      <div class="square" id="BoxTesto">
+        Benvenuto! Seleziona un'azione per iniziare l'avventura.
+      </div>
 
       <!-- Box destro con inventario (popolato dinamicamente) -->
       <div class="side-box" id="MenuDestro">
@@ -35,12 +38,7 @@
       </div>
     </div>
   </div>
-
-  <!-- ===== BOX INFERIORE FLESSIBILE ===== -->
   <div class="box-bottom" id="PièDiPagina">
-    <div class="box-text" id="BoxTesto">
-      Benvenuto! Seleziona un'azione per iniziare l'avventura.
-    </div>
     <div class="action-panel">
       <!-- Gruppo Movimento (Sinistra) -->
       <div class="button-group" id="movementGroup" data-label="MOVIMENTO">

--- a/styles.css
+++ b/styles.css
@@ -151,6 +151,26 @@ body::before {
   box-shadow: 0 0 10px rgba(255, 0, 106, 0.5);
 }
 
+/* Stile dedicato al nuovo box testo affiancato all'immagine */
+#BoxTesto {
+  border: 2px solid #ff006a;
+  border-radius: 6px;
+  padding: 1vh;
+  overflow-y: auto;
+  background:
+    linear-gradient(135deg, rgba(0, 0, 0, 0.95) 0%, rgba(20, 0, 15, 0.98) 100%);
+  backdrop-filter: blur(5px);
+  font-size: 2.2vh;
+  line-height: 1.4;
+  color: #ffffff;
+  box-shadow:
+    0 0 15px rgba(255, 0, 106, 0.4),
+    inset 0 1px 0 rgba(255, 0, 106, 0.1);
+  text-shadow: 0 0 3px rgba(0, 255, 255, 0.3);
+  font-family: 'Orbitron', monospace;
+  letter-spacing: 0.5px;
+}
+
 /* ------------------------------------------------
    BARRA INFERIORE PER I PULSANTI AZIONE (".box-bottom")
    ------------------------------------------------ */
@@ -247,8 +267,8 @@ body::before {
   height: calc(100% - 10px);
   align-self: stretch;
   color: #ffffff;
-  width: calc(100vw - 15vw - 8vw - 8vh);
-  min-width: 400px;
+  width: calc((100vw - 15vw - 8vw - 8vh) / 2);
+  min-width: 200px;
   border: 3px solid #ffd700;
   border-radius: 10px;
   margin: 0 5px;


### PR DESCRIPTION
## Summary
- split the main display into two square boxes
- remove old bottom text box
- style new text square and enlarge its font

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68437ce3bba88326ab0eb1791690a1d4