### PR TITLE
Improve start game transition

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -93,8 +93,11 @@
         localStorage.setItem('pendingSaveName', name);
         localStorage.setItem('startIntroCutscene', 'true');
         localStorage.removeItem(key);
-        if (transitionOverlay) transitionOverlay.style.display = 'block';
-        setTimeout(() => { window.location.href = 'game.html'; }, 300);
+        if (transitionOverlay) {
+            transitionOverlay.classList.remove('fade-out');
+            transitionOverlay.style.display = 'block';
+        }
+        setTimeout(() => { window.location.href = 'game.html'; }, 600);
     }
 
     function showMainMenu() {
@@ -141,8 +144,11 @@
             loadBtn.disabled = !saveData;
             loadBtn.addEventListener('click', () => {
                 localStorage.setItem('currentSaveSlot', slot);
-                if (transitionOverlay) transitionOverlay.style.display = 'block';
-                setTimeout(() => { window.location.href = 'game.html'; }, 300);
+                if (transitionOverlay) {
+                    transitionOverlay.classList.remove('fade-out');
+                    transitionOverlay.style.display = 'block';
+                }
+                setTimeout(() => { window.location.href = 'game.html'; }, 600);
             });
             wrapper.appendChild(loadBtn);
 

--- a/script.js
+++ b/script.js
@@ -47,11 +47,20 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
   let volumeLevel = 1.0;
 
   function showTransition() {
-    if (transitionOverlay) transitionOverlay.style.display = 'block';
+    if (transitionOverlay) {
+      transitionOverlay.classList.remove('fade-out');
+      transitionOverlay.style.display = 'block';
+    }
   }
 
   function hideTransition() {
-    if (transitionOverlay) transitionOverlay.style.display = 'none';
+    if (transitionOverlay) {
+      transitionOverlay.classList.add('fade-out');
+      transitionOverlay.addEventListener('animationend', () => {
+        transitionOverlay.style.display = 'none';
+        transitionOverlay.classList.remove('fade-out');
+      }, { once: true });
+    }
   }
 
   let currentVerb = null;     // Verbo selezionato (e.g. "USA", "GUARDA")
@@ -747,7 +756,7 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
         } else {
           await window.LocationManager.initialize();
         }
-        hideTransition();
+        setTimeout(hideTransition, 100);
       } catch (error) {
         console.error("❌ Errore nell'inizializzazione LocationManager:", error);
         showStatus("❌ Errore nel caricamento del sistema multi-location", true);
@@ -759,7 +768,7 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
       if (!success) {
         showStatus("❌ Errore nell'inizializzazione del gioco singola location", true);
       }
-      hideTransition();
+      setTimeout(hideTransition, 100);
     } else {
       // Nessun dato disponibile
       console.warn("⚠️ Nessun sistema di gioco disponibile");
@@ -779,7 +788,7 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
           <p><small>Apri la console (F12) per maggiori dettagli.</small></p>
         `;
       }
-      hideTransition();
+      setTimeout(hideTransition, 100);
     }
   }
 

--- a/styles.css
+++ b/styles.css
@@ -943,6 +943,11 @@ button:not(.selected):hover {
   animation: glitchAnimation 0.8s steps(2, end) infinite;
 }
 
+.transition-overlay.fade-out {
+  animation: glitchAnimation 0.8s steps(2, end) infinite,
+             glitchFadeOut 0.4s forwards;
+}
+
 @keyframes glitchAnimation {
   0% { clip-path: inset(0 0 90% 0); opacity: 0.8; }
   20% { clip-path: inset(10% 0 70% 0); }
@@ -950,6 +955,11 @@ button:not(.selected):hover {
   60% { clip-path: inset(30% 0 50% 0); }
   80% { clip-path: inset(40% 0 40% 0); }
   100% { clip-path: inset(50% 0 30% 0); opacity: 0.8; }
+}
+
+@keyframes glitchFadeOut {
+  from { opacity: 1; }
+  to   { opacity: 0; }
 }
 
 


### PR DESCRIPTION
## Summary
- enhance futuristic glitch transition with fade-out animation
- delay hide of transition overlay after initializing game
- show transition overlay longer before loading game scene

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843ecf1b800832693b907ded4957941