### PR TITLE
Improve dialogue UI and transitions

### DIFF
--- a/dialogueManager.js
+++ b/dialogueManager.js
@@ -42,19 +42,22 @@ const DialogueManager = {
             if (window.GameState && data.flag) {
                 window.GameState.setDialogueFlag(data.flag);
             }
-            const options = (data.options || []).map(opt => ({
-                text: opt.text,
-                onSelect: () => {
+            const options = [];
+            (data.options || []).forEach(opt => {
+                const optionObj = { text: opt.text };
+                optionObj.onSelect = () => {
                     setTimeout(() => {
-                        window.showDialogue(data.image || '', opt.response, [
-                            { text: 'Chiudi', onSelect: () => {
-                                if (window.hideDialogue) window.hideDialogue();
-                            } }
-                        ]);
+                        window.showDialogue(data.image || '', opt.response, optionsWithClose);
                     }, 0);
-                }
-            }));
-            window.showDialogue(data.image || '', data.text, options);
+                };
+                options.push(optionObj);
+            });
+
+            const optionsWithClose = options.concat([{ text: 'Non ho altro da dirti', onSelect: () => {
+                if (window.hideDialogue) window.hideDialogue();
+            }}]);
+
+            window.showDialogue(data.image || '', data.text, optionsWithClose);
         } catch (error) {
             console.error('Errore caricamento dialogo:', error);
             if (window.gameInterface && window.gameInterface.showMessage) {

--- a/script.js
+++ b/script.js
@@ -50,13 +50,14 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
     if (transitionOverlay) {
       transitionOverlay.classList.remove('fade-out');
       transitionOverlay.style.display = 'block';
+      transitionOverlay.style.opacity = '1';
     }
   }
 
   function hideTransition() {
     if (transitionOverlay) {
       transitionOverlay.classList.add('fade-out');
-      transitionOverlay.addEventListener('animationend', () => {
+      transitionOverlay.addEventListener('transitionend', () => {
         transitionOverlay.style.display = 'none';
         transitionOverlay.classList.remove('fade-out');
       }, { once: true });
@@ -659,7 +660,7 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
     if (dialogueText) dialogueText.textContent = text || '';
     if (dialogueOptions) {
       dialogueOptions.innerHTML = '';
-      (options || []).slice(0, 4).forEach(opt => {
+      (options || []).slice(0, 8).forEach(opt => {
         const btn = document.createElement('button');
         btn.className = 'dialogue-option-button';
         const label = typeof opt === 'string' ? opt : opt.text;

--- a/styles.css
+++ b/styles.css
@@ -193,6 +193,7 @@ body::before {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
+  align-items: center;
   padding: 1vh;
   gap: 0.3vh;
   background: 
@@ -234,12 +235,20 @@ body::before {
   margin-right: 5px;
   margin-left: 5px;
   overflow-y: visible;
-  background: 
+  background:
     linear-gradient(145deg, rgba(0, 0, 0, 0.8) 0%, rgba(10, 0, 20, 0.9) 100%);
   border-color: #e91e63;
   box-shadow: 
     0 0 15px rgba(233, 30, 99, 0.3),
     inset 0 1px 0 rgba(233, 30, 99, 0.1);
+}
+
+#PoiList,
+#InventoryList {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
 }
 
 .square {
@@ -890,7 +899,7 @@ button:not(.selected):hover {
 }
 
 .dialogue-text-box {
-  flex: 1;
+  flex: 0 0 30%;
   border: 2px solid #ff006a;
   border-radius: 6px;
   padding: 1vh;
@@ -940,26 +949,12 @@ button:not(.selected):hover {
   background: #000;
   z-index: 3000;
   pointer-events: none;
-  animation: glitchAnimation 0.8s steps(2, end) infinite;
+  opacity: 1;
+  transition: opacity 0.4s ease;
 }
 
 .transition-overlay.fade-out {
-  animation: glitchAnimation 0.8s steps(2, end) infinite,
-             glitchFadeOut 0.4s forwards;
-}
-
-@keyframes glitchAnimation {
-  0% { clip-path: inset(0 0 90% 0); opacity: 0.8; }
-  20% { clip-path: inset(10% 0 70% 0); }
-  40% { clip-path: inset(20% 0 60% 0); }
-  60% { clip-path: inset(30% 0 50% 0); }
-  80% { clip-path: inset(40% 0 40% 0); }
-  100% { clip-path: inset(50% 0 30% 0); opacity: 0.8; }
-}
-
-@keyframes glitchFadeOut {
-  from { opacity: 1; }
-  to   { opacity: 0; }
+  opacity: 0;
 }
 
 


### PR DESCRIPTION
## Summary
- smooth fade transitions
- center POI and inventory buttons
- reduce dialogue text box height for more options
- keep options visible after NPC replies and add closing button

## Testing
- `node -e "require('./dialogueManager.js')"` *(fails: document not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6843f9ae6d688326a6a53c6a8e6e3139