### PR TITLE
Add random initial inventory items

### DIFF
--- a/gameState.js
+++ b/gameState.js
@@ -219,6 +219,19 @@ const GameState = {
     
     // Imposta stato iniziale del gioco (solo al primo avvio)
     setupInitialGameState() {
+        // Se l'inventario di partenza è vuoto, popola con 20 oggetti casuali
+        if (this.gameInitialState.startingInventory.length === 0 &&
+            typeof window.getAllItemNames === 'function') {
+            const names = window.getAllItemNames();
+            const numberToAdd = Math.min(20, names.length);
+            while (this.gameInitialState.startingInventory.length < numberToAdd) {
+                const randomName = names[Math.floor(Math.random() * names.length)];
+                if (!this.gameInitialState.startingInventory.includes(randomName)) {
+                    this.gameInitialState.startingInventory.push(randomName);
+                }
+            }
+        }
+
         // Imposta inventario iniziale
         this.gameInitialState.startingInventory.forEach(item => {
             this.addItem(item);


### PR DESCRIPTION
## Summary
- populate starting inventory with 20 random objects when starting a new game

## Testing
- `node -e "global.window={document:{getElementById:()=>null,addEventListener:(e,f)=>f()},localStorage:{setItem:()=>{},getItem:()=>null,removeItem:()=>{}}};global.document=window.document;require('./items.js');require('./gameState.js');window.GameState.updateInventoryInterface=()=>{};console.log(window.GameState.inventory.length);"`

------
https://chatgpt.com/codex/tasks/task_e_68442b103ba083269d3c8224b1e881de