### PR TITLE
Improve button hover behavior

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -286,7 +286,7 @@ body::before {
   font-weight: 600;
   cursor: pointer;
   margin: 0.4vh 0;
-  background: 
+  background:
     linear-gradient(145deg, rgba(0, 20, 20, 0.95) 0%, rgba(0, 40, 40, 0.9) 100%);
   border: 1px solid #64ffda;
   border-radius: 6px;
@@ -298,20 +298,22 @@ body::before {
   text-transform: uppercase;
   letter-spacing: 1px;
   text-shadow: 0 0 2px rgba(100, 255, 218, 0.4);
-  box-shadow: 
+  box-shadow:
     0 2px 10px rgba(100, 255, 218, 0.2),
     inset 0 1px 0 rgba(100, 255, 218, 0.1);
+  filter: hue-rotate(0deg);
 }
 
 .left-button:hover {
-  background: 
-    linear-gradient(145deg, rgba(0, 40, 40, 0.98) 0%, rgba(0, 60, 60, 0.95) 100%);
-  border-color: #64ffda;
-  transform: translateX(2px) scale(1.02);
-  box-shadow: 
-    0 4px 20px rgba(100, 255, 218, 0.4),
-    inset 0 1px 0 rgba(100, 255, 218, 0.2);
-  text-shadow: 0 0 4px rgba(100, 255, 218, 0.6);
+  background:
+    linear-gradient(145deg, rgba(255, 100, 137, 0.95) 0%, rgba(155, 0, 37, 0.9) 100%);
+  border-color: #ff6489;
+  box-shadow:
+    0 4px 20px rgba(255, 100, 137, 0.4),
+    inset 0 1px 0 rgba(255, 100, 137, 0.2);
+  text-shadow: 0 0 4px rgba(255, 100, 137, 0.6);
+  filter: hue-rotate(180deg);
+  transform: none;
 }
 
 /* ============================
@@ -340,6 +342,7 @@ body::before {
   box-shadow:
     0 2px 10px rgba(233, 30, 99, 0.2),
     inset 0 1px 0 rgba(233, 30, 99, 0.1);
+  filter: hue-rotate(0deg);
 }
 
 .inventory-button .inventory-icon {
@@ -351,14 +354,15 @@ body::before {
 }
 
 .inventory-button:hover {
-  background: 
-    linear-gradient(145deg, rgba(40, 0, 20, 0.98) 0%, rgba(60, 0, 30, 0.95) 100%);
-  border-color: #ff4081;
-  transform: translateX(-1px) scale(1.02);
-  box-shadow: 
-    0 4px 20px rgba(233, 30, 99, 0.4),
-    inset 0 1px 0 rgba(233, 30, 99, 0.2);
-  text-shadow: 0 0 4px rgba(255, 64, 129, 0.6);
+  background:
+    linear-gradient(145deg, rgba(30, 233, 164, 0.95) 0%, rgba(0, 120, 80, 0.9) 100%);
+  border-color: #1ee9a4;
+  box-shadow:
+    0 4px 20px rgba(30, 233, 164, 0.4),
+    inset 0 1px 0 rgba(30, 233, 164, 0.2);
+  text-shadow: 0 0 4px rgba(30, 233, 164, 0.6);
+  filter: hue-rotate(180deg);
+  transform: none;
 }
 
 /* ============================
@@ -663,7 +667,7 @@ body::before {
 }
 
 /* Hover effect per tutti i bottoni */
-button:not(.selected):hover {
+button:not(.selected):not(.left-button):not(.inventory-button):not(.dialogue-option-button):hover {
   animation: buttonHover 0.3s ease forwards;
 }
 
@@ -945,6 +949,17 @@ button:not(.selected):hover {
   box-shadow:
     0 2px 10px rgba(0, 255, 100, 0.3),
     inset 0 1px 0 rgba(0, 255, 100, 0.3);
+  filter: hue-rotate(0deg);
+}
+
+.dialogue-option-button:hover {
+  background: linear-gradient(145deg, rgba(255, 0, 155, 0.95) 0%, rgba(150, 0, 100, 0.9) 100%);
+  border-color: #ff009b;
+  box-shadow:
+    0 4px 20px rgba(255, 0, 155, 0.4),
+    inset 0 1px 0 rgba(255, 0, 155, 0.2);
+  filter: hue-rotate(180deg);
+  transform: none;
 }
 
 /* ========================


### PR DESCRIPTION
## Summary
- remove scaling on left, inventory and dialogue option buttons
- show complementary colors on hover
- exclude these buttons from the global hover animation

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68443878aba48326bd1fd763b6adce89