### PR TITLE
Enable inventory item zoom

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -663,10 +663,18 @@ body::before {
 
 /* Glitch effect per il contenuto principale quando carica */
 .square img {
-  filter: 
+  filter:
     drop-shadow(0 0 10px rgba(255, 215, 0, 0.3))
     drop-shadow(2px 0 0 rgba(255, 0, 255, 0.1))
     drop-shadow(-2px 0 0 rgba(0, 255, 255, 0.1));
+}
+
+/* Visualizzazione oggetti dell'inventario */
+.item-view #sceneImage {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  aspect-ratio: 1 / 1;
 }
 
 /* Hover effect per tutti i bottoni */


### PR DESCRIPTION
## Summary
- show inventory items in the scene when using *guarda*
- disable buttons during item view and re-enable with X
- style zoomed images to stay square

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684442aa7e648326807736bf4adb9690