### PR TITLE
Maintain selection when inspecting inventory items

### DIFF
--- a/script.js
+++ b/script.js
@@ -307,8 +307,6 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
   function showItemView(itemData) {
     if (!itemData || !itemData.image || !sceneImage) return;
 
-    resetVerbState();
-
     isViewingItem = true;
     previousImageSrc = sceneImage.src;
     sceneImage.src = itemData.image;
@@ -333,6 +331,7 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
     sceneImage.style.aspectRatio = '';
     sceneImage.src = previousImageSrc || sceneImage.src;
     ContenutoPrincipale.classList.remove('item-view');
+    resetVerbState();
     loadScene();
   }
 


### PR DESCRIPTION
## Summary
- keep `GUARDA` and selected inventory item highlighted while viewing item
- clear selections when closing the item view

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_6844488c827c83269ba55f1a18704e95