### PR TITLE
Fix inventory hover and expand journal

### DIFF
--- a/journalData.js
+++ b/journalData.js
@@ -1,6 +1,9 @@
 const JournalData = {
     categories: {
-        armi: 'Armi'
+        armi: 'Armi',
+        personaggi: 'Personaggi',
+        luoghi: 'Luoghi',
+        fazioni: 'Fazioni'
     },
     entries: {
         armi: {
@@ -10,7 +13,10 @@ const JournalData = {
                 image: 'assets/images/items/hf27_laser.png',
                 description: 'Pistola dalla storia gloriosa ma ormai superata, ancora solida nonostante l\'et\u00e0.'
             }
-        }
+        },
+        personaggi: {},
+        luoghi: {},
+        fazioni: {}
     }
 };
 

--- a/styles.css
+++ b/styles.css
@@ -360,6 +360,7 @@ body::before {
   background:
     linear-gradient(145deg, rgba(255, 255, 0, 0.95) 0%, rgba(200, 200, 0, 0.9) 100%);
   border-color: #ffff00;
+  color: #000000;
   box-shadow:
     0 4px 20px rgba(255, 255, 0, 0.5),
     inset 0 1px 0 rgba(255, 255, 0, 0.3);
@@ -516,6 +517,7 @@ body::before {
 .menu-buttons button:hover {
   background: linear-gradient(145deg, rgba(255, 255, 0, 0.95) 0%, rgba(200, 200, 0, 0.9) 100%);
   border-color: #ffff00;
+  color: #000000;
   box-shadow:
     0 4px 20px rgba(255, 255, 0, 0.5),
     inset 0 1px 0 rgba(255, 255, 0, 0.3);
@@ -1009,6 +1011,7 @@ button:not(.selected):not(.left-button):not(.inventory-button):not(.dialogue-opt
 .dialogue-option-button:hover {
   background: linear-gradient(145deg, rgba(255, 255, 0, 0.95) 0%, rgba(200, 200, 0, 0.9) 100%);
   border-color: #ffff00;
+  color: #000000;
   box-shadow:
     0 4px 20px rgba(255, 255, 0, 0.5),
     inset 0 1px 0 rgba(255, 255, 0, 0.3);


### PR DESCRIPTION
## Summary
- keep inventory buttons static on hover and darken text on yellow background
- make all yellow-hovered buttons use dark text
- extend journal categories with Personaggi, Luoghi, and Fazioni

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68445e60db9c8326ae08818109887560