### PR TITLE
Center text in BoxTesto

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -158,9 +158,13 @@ body::before {
   border-radius: 6px;
   padding: 1vh;
   overflow-y: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background:
     linear-gradient(135deg, rgba(0, 0, 0, 0.95) 0%, rgba(20, 0, 15, 0.98) 100%);
   backdrop-filter: blur(5px);
+  text-align: center;
   font-size: 2.2vh;
   line-height: 1.4;
   color: #ffffff;


### PR DESCRIPTION
## Summary
- center text both vertically and horizontally inside the BoxTesto container so scene messages appear centered

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844a749dac48326b1ed3628f189ce19