### PR TITLE
Implement quest progress tracking and new quest UI

### DIFF
--- a/game.html
+++ b/game.html
@@ -107,8 +107,11 @@
   <div id="questsOverlay" class="overlay-screen" style="display:none;">
     <div class="quest-window">
       <h2>QUESTS</h2>
-      <div id="mainQuestList"></div>
-      <div id="sideQuestList"></div>
+      <div class="quest-columns">
+        <div id="questCategories" class="quest-column categories"></div>
+        <div id="questList" class="quest-column quests"></div>
+        <div id="questDetails" class="quest-column details"></div>
+      </div>
       <button id="achievementsOpenBtn" class="inventory-button">ACHIEVEMENTS</button>
       <button id="closeQuestsBtn" class="inventory-button">INDIETRO</button>
     </div>

--- a/gameState.js
+++ b/gameState.js
@@ -60,6 +60,9 @@ const GameState = {
             if (jFlag) {
                 this.setJournalFlag(jFlag);
             }
+            if (itemName === 'Chiave' && window.QuestManager) {
+                window.QuestManager.markTaskCompleted('main', 'fuga_castello', 0);
+            }
             this.updateInventoryInterface();
             this.saveToStorage();
             console.log(`📦 Aggiunto: ${itemName}`);
@@ -85,6 +88,9 @@ const GameState = {
     // ===== METODI FLAG =====
     setFlag(flagName) {
         this.flags[flagName] = true;
+        if (flagName === 'porta_aperta' && window.QuestManager) {
+            window.QuestManager.markTaskCompleted('main', 'fuga_castello', 1);
+        }
         this.saveToStorage();
         console.log(`🚩 Flag impostato: ${flagName}`);
     },

--- a/quests.js
+++ b/quests.js
@@ -12,3 +12,23 @@ const Quests = {
 };
 
 window.Quests = Quests;
+
+const QuestManager = {
+    markTaskCompleted(category, questId, taskIndex) {
+        let quest = null;
+        if (category === 'main' && Quests.main.id === questId) {
+            quest = Quests.main;
+        } else if (category === 'sides') {
+            quest = Quests.sides.find(q => q.id === questId);
+        }
+        if (!quest || !quest.tasks[taskIndex]) return;
+        if (!quest.tasks[taskIndex].completed) {
+            quest.tasks[taskIndex].completed = true;
+            if (typeof window.updateQuestOverlay === 'function') {
+                window.updateQuestOverlay();
+            }
+        }
+    }
+};
+
+window.QuestManager = QuestManager;

--- a/script.js
+++ b/script.js
@@ -52,8 +52,9 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
   const questsOverlay = document.getElementById('questsOverlay');
   const achievementsOverlay = document.getElementById('achievementsOverlay');
   const journalOverlay = document.getElementById('journalOverlay');
-  const mainQuestList = document.getElementById('mainQuestList');
-  const sideQuestList = document.getElementById('sideQuestList');
+  const questCategories = document.getElementById('questCategories');
+  const questList = document.getElementById('questList');
+  const questDetails = document.getElementById('questDetails');
   const achievementsGrid = document.getElementById('achievementsGrid');
   const journalCategories = document.getElementById('journalCategories');
   const journalEntries = document.getElementById('journalEntries');
@@ -792,37 +793,59 @@ const interactionButtons = [usaButton, guardaButton, prendiButton, parlaButton,
 
   // ====== QUESTS & JOURNAL UI ======
   function updateQuestOverlay() {
-    if (!mainQuestList || !sideQuestList) return;
-    mainQuestList.innerHTML = '';
-    sideQuestList.innerHTML = '';
-    const main = window.Quests?.main;
-    if (main) {
-      const title = document.createElement('h3');
-      title.textContent = main.name;
-      mainQuestList.appendChild(title);
-      const ul = document.createElement('ul');
-      main.tasks.forEach(t => {
-        const li = document.createElement('li');
-        li.textContent = (t.completed ? '[x] ' : '[ ] ') + t.description;
-        ul.appendChild(li);
-      });
-      mainQuestList.appendChild(ul);
-    }
-    (window.Quests?.sides || []).forEach(q => {
-      const wrapper = document.createElement('div');
-      const h = document.createElement('h4');
-      h.textContent = q.name;
-      wrapper.appendChild(h);
-      const ul = document.createElement('ul');
-      q.tasks.forEach(t => {
-        const li = document.createElement('li');
-        li.textContent = (t.completed ? '[x] ' : '[ ] ') + t.description;
-        ul.appendChild(li);
-      });
-      wrapper.appendChild(ul);
-      sideQuestList.appendChild(wrapper);
+    if (!questCategories || !questList || !questDetails) return;
+    questCategories.innerHTML = '';
+    questList.innerHTML = '';
+    questDetails.innerHTML = '';
+    const categories = { main: 'MAIN QUEST', sides: 'SIDE QUEST' };
+    Object.keys(categories).forEach(cat => {
+      const btn = document.createElement('button');
+      btn.className = 'inventory-button';
+      btn.textContent = categories[cat];
+      btn.addEventListener('click', () => loadQuestList(cat));
+      questCategories.appendChild(btn);
     });
   }
+
+  function loadQuestList(cat) {
+    questList.innerHTML = '';
+    questDetails.innerHTML = '';
+    const quests = cat === 'main' ? [window.Quests.main] : window.Quests.sides || [];
+    quests.forEach(q => {
+      const btn = document.createElement('button');
+      btn.className = 'inventory-button';
+      btn.textContent = q.name;
+      btn.addEventListener('click', () => showQuestDetails(cat, q.id));
+      questList.appendChild(btn);
+    });
+  }
+
+  function showQuestDetails(cat, questId) {
+    questDetails.innerHTML = '';
+    let quest = null;
+    if (cat === 'main' && window.Quests.main.id === questId) {
+      quest = window.Quests.main;
+    } else if (cat === 'sides') {
+      quest = (window.Quests.sides || []).find(q => q.id === questId);
+    }
+    if (!quest) return;
+    const h = document.createElement('h3');
+    h.textContent = quest.name;
+    questDetails.appendChild(h);
+    const ul = document.createElement('ul');
+    quest.tasks.forEach(t => {
+      const li = document.createElement('li');
+      li.textContent = t.description;
+      li.className = t.completed ? 'quest-completed' : 'quest-pending';
+      ul.appendChild(li);
+    });
+    questDetails.appendChild(ul);
+  }
+
+  // Rendi accessibili anche esternamente per il QuestManager
+  window.updateQuestOverlay = updateQuestOverlay;
+  window.loadQuestList = loadQuestList;
+  window.showQuestDetails = showQuestDetails;
 
   function updateAchievementsOverlay() {
     if (!achievementsGrid) return;

--- a/styles.css
+++ b/styles.css
@@ -1207,4 +1207,26 @@ button:not(.selected):not(.left-button):not(.inventory-button):not(.dialogue-opt
 .journal-column.details img { max-width: 100%; height: auto; margin-bottom: 1vh; }
 .journal-text { flex: 1; overflow-y: auto; }
 
+.quest-columns {
+  display: flex;
+  width: 100%;
+  height: 60vh;
+  gap: 1vh;
+  margin-bottom: 2vh;
+}
+
+.quest-column {
+  border: 1px solid #00ffff;
+  border-radius: 4px;
+  padding: 1vh;
+  overflow-y: auto;
+}
+
+.quest-column.categories { width: 25%; }
+.quest-column.quests { width: 25%; }
+.quest-column.details { width: 50%; }
+
+.quest-completed { color: #00ff00; }
+.quest-pending { color: #ff00ff; }
+
 


### PR DESCRIPTION
## Summary
- track quest completion when collecting the key and opening the door
- expose a global `QuestManager` and helper functions
- redesign QUESTS overlay with three columns like the journal
- style quest overlay and show color-coded progress

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844b488ee5c8326919f616cee8f48a7