### PR TITLE
Add map preview and language system

### DIFF
--- a/game.html
+++ b/game.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Adventure GUI Framework</title>
   <link rel="stylesheet" href="styles.css">
+  <script src="translations.js"></script>
 </head>
 <body>
 
@@ -13,7 +14,7 @@
     <div class="middle-content">
       <!-- Box sinistro - punti di interesse (popolato dinamicamente) -->
       <div class="side-box" id="MenuSinistro">
-        <h3 class="side-title">Points of interest</h3>
+        <h3 class="side-title" data-i18n="poi_title">Points of interest</h3>
         <div id="PoiList"></div>
       </div>
 
@@ -27,13 +28,13 @@
           <p><small>Se vedi questo messaggio, verifica che i file di gioco siano caricati correttamente.</small></p>
         </div>
       </div>
-      <div class="square" id="BoxTesto">
+      <div class="square" id="BoxTesto" data-i18n="welcome_msg">
         Benvenuto! Seleziona un'azione per iniziare l'avventura.
       </div>
 
       <!-- Box destro con inventario (popolato dinamicamente) -->
       <div class="side-box" id="MenuDestro">
-        <h3 class="side-title">Inventory</h3>
+        <h3 class="side-title" data-i18n="inventory_title">Inventory</h3>
         <div id="InventoryList"></div>
       </div>
     </div>
@@ -80,8 +81,8 @@
       </div>
 
   <div class="settings-panel">
-    <button id="mainMenuBtn">MAIN MENU</button>
-    <button id="optionsMenuBtn">OPZIONI</button>
+    <button id="mainMenuBtn" data-i18n="main_menu">MAIN MENU</button>
+    <button id="optionsMenuBtn" data-i18n="options">OPZIONI</button>
     <button id="audioToggle" aria-label="Audio">🔊</button>
     <input type="range" id="volumeSlider" min="0" max="100" value="100">
   </div>
@@ -111,29 +112,29 @@
   <!-- ===== QUESTS OVERLAY ===== -->
   <div id="questsOverlay" class="overlay-screen" style="display:none;">
     <div class="quest-window">
-      <h2>QUESTS</h2>
+      <h2 data-i18n="quests_title">QUESTS</h2>
       <div class="quest-columns">
         <div id="questCategories" class="quest-column categories"></div>
         <div id="questList" class="quest-column quests"></div>
         <div id="questDetails" class="quest-column details"></div>
       </div>
-      <button id="closeQuestsBtn" class="inventory-button">INDIETRO</button>
+      <button id="closeQuestsBtn" class="inventory-button" data-i18n="back">INDIETRO</button>
     </div>
   </div>
 
   <!-- ===== ACHIEVEMENTS OVERLAY ===== -->
   <div id="achievementsOverlay" class="overlay-screen" style="display:none;">
     <div class="achievements-window">
-      <h2>ACHIEVEMENTS</h2>
+      <h2 data-i18n="achievements_title">ACHIEVEMENTS</h2>
       <div id="achievementsGrid" class="achievements-grid"></div>
-      <button id="closeAchievementsBtn" class="inventory-button">INDIETRO</button>
+      <button id="closeAchievementsBtn" class="inventory-button" data-i18n="back">INDIETRO</button>
     </div>
   </div>
 
   <!-- ===== JOURNAL OVERLAY ===== -->
   <div id="journalOverlay" class="overlay-screen" style="display:none;">
     <div class="journal-window">
-      <h2>JOURNAL</h2>
+      <h2 data-i18n="journal_title">JOURNAL</h2>
       <div class="journal-columns">
         <div id="journalCategories" class="journal-column categories"></div>
         <div id="journalEntries" class="journal-column entries"></div>
@@ -142,33 +143,40 @@
           <div id="journalText" class="journal-text"></div>
         </div>
       </div>
-      <button id="closeJournalBtn" class="inventory-button">INDIETRO</button>
+      <button id="closeJournalBtn" class="inventory-button" data-i18n="back">INDIETRO</button>
     </div>
   </div>
 
   <!-- ===== MAP OVERLAY ===== -->
   <div id="mapOverlay" class="overlay-screen" style="display:none;">
     <div class="map-window">
-      <h2>MAPPA</h2>
-      <div class="map-grid-wrapper">
-        <div id="mapGrid" class="map-grid"></div>
+      <h2 data-i18n="map_title">MAPPA</h2>
+      <div class="map-content">
+        <div class="map-grid-wrapper">
+          <div id="mapGrid" class="map-grid"></div>
+        </div>
+        <div id="mapPreview" class="map-preview">
+          <img id="previewImage" src="" alt="preview" style="display:none;" />
+          <div id="previewName"></div>
+          <button id="goHereBtn" class="inventory-button" data-i18n="go_here" style="display:none;">VAI QUI</button>
+        </div>
       </div>
-      <button id="closeMapBtn" class="inventory-button">INDIETRO</button>
+      <button id="closeMapBtn" class="inventory-button" data-i18n="back">INDIETRO</button>
     </div>
   </div>
 
   <!-- ===== OPTIONS OVERLAY ===== -->
   <div id="optionsOverlay" class="overlay-screen" style="display:none;">
     <div class="options-window">
-      <h2>OPZIONI</h2>
-      <label><input type="checkbox" id="optionsAudioToggle"> AUDIO</label>
+      <h2 data-i18n="options">OPZIONI</h2>
+      <label><input type="checkbox" id="optionsAudioToggle"> <span data-i18n="audio">AUDIO</span></label>
       <input type="range" id="optionsVolumeSlider" min="0" max="100" value="100">
-      <label for="languageSelect">LINGUA</label>
-      <select id="languageSelect">
+      <label for="languageSelect" data-i18n="language">LINGUA</label>
+      <select id="languageSelect" class="language-select">
         <option value="it">ITALIANO</option>
         <option value="en">INGLESE</option>
       </select>
-      <button id="closeOptionsBtn" class="inventory-button">CHIUDI</button>
+      <button id="closeOptionsBtn" class="inventory-button" data-i18n="close">CHIUDI</button>
     </div>
   </div>
 
@@ -178,8 +186,8 @@
     <div class="modal-window">
       <div id="modalMessage"></div>
       <div class="modal-buttons">
-        <button id="modalOkBtn">OK</button>
-        <button id="modalCancelBtn">Annulla</button>
+        <button id="modalOkBtn" data-i18n="ok">OK</button>
+        <button id="modalCancelBtn" data-i18n="cancel">Annulla</button>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -5,50 +5,51 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Adventure Game - Menu</title>
     <link rel="stylesheet" href="styles.css">
+    <script src="translations.js"></script>
 </head>
 <body class="menu-screen">
     <audio id="menuMusic" src="assets/music/main_menu_theme.mp3" loop></audio>
     <div id="mainMenu" class="menu-container">
         <div class="menu-buttons">
             <h1>Adventure Game</h1>
-            <button id="newGameBtn">Nuova Partita</button>
-            <button id="loadGameBtn">Carica Partita</button>
-            <button id="optionsBtn">Opzioni</button>
-            <button id="creditsBtn">Credits</button>
-            <button id="quitBtn">Esci dal Gioco</button>
+            <button id="newGameBtn" data-i18n="new_game">Nuova Partita</button>
+            <button id="loadGameBtn" data-i18n="load_game">Carica Partita</button>
+            <button id="optionsBtn" data-i18n="options">Opzioni</button>
+            <button id="creditsBtn" data-i18n="credits">Credits</button>
+            <button id="quitBtn" data-i18n="quit_game">Esci dal Gioco</button>
         </div>
     </div>
 
     <div id="loadScreen" class="menu-container" style="display:none;">
         <div class="menu-buttons">
-            <h1>Carica Partita</h1>
+            <h1 data-i18n="load_game">Carica Partita</h1>
             <div id="slotGrid" class="slot-grid"></div>
-            <button id="backBtn">Indietro</button>
+            <button id="backBtn" data-i18n="back">Indietro</button>
         </div>
     </div>
 
     <div id="newGameScreen" class="menu-container" style="display:none;">
         <div class="menu-buttons">
-            <h1>Nuova Partita</h1>
-            <input id="saveNameInput" class="save-name-input" type="text" placeholder="Nome salvataggio" />
+            <h1 data-i18n="new_game">Nuova Partita</h1>
+            <input id="saveNameInput" class="save-name-input" type="text" placeholder="Nome salvataggio" data-i18n-placeholder="save_name" />
             <div id="newSlotGrid" class="slot-grid"></div>
-            <button id="createGameBtn">Avvia</button>
-            <button id="cancelNewGameBtn">Annulla</button>
+            <button id="createGameBtn" data-i18n="start">Avvia</button>
+            <button id="cancelNewGameBtn" data-i18n="cancel">Annulla</button>
         </div>
     </div>
 
     <!-- ===== OPTIONS OVERLAY ===== -->
     <div id="optionsOverlay" class="overlay-screen" style="display:none;">
         <div class="options-window">
-            <h2>OPZIONI</h2>
-            <label><input type="checkbox" id="optionsAudioToggle"> AUDIO</label>
+            <h2 data-i18n="options">OPZIONI</h2>
+            <label><input type="checkbox" id="optionsAudioToggle"> <span data-i18n="audio">AUDIO</span></label>
             <input type="range" id="optionsVolumeSlider" min="0" max="100" value="100">
-            <label for="languageSelect">LINGUA</label>
-            <select id="languageSelect">
+            <label for="languageSelect" data-i18n="language">LINGUA</label>
+            <select id="languageSelect" class="language-select">
                 <option value="it">ITALIANO</option>
                 <option value="en">INGLESE</option>
             </select>
-            <button id="closeOptionsBtn" class="inventory-button">CHIUDI</button>
+            <button id="closeOptionsBtn" class="inventory-button" data-i18n="close">CHIUDI</button>
         </div>
     </div>
 
@@ -58,8 +59,8 @@
         <div class="modal-window">
             <div id="modalMessage"></div>
             <div class="modal-buttons">
-                <button id="modalOkBtn">OK</button>
-                <button id="modalCancelBtn">Annulla</button>
+                <button id="modalOkBtn" data-i18n="ok">OK</button>
+                <button id="modalCancelBtn" data-i18n="cancel">Annulla</button>
             </div>
         </div>
     </div>

--- a/menu.js
+++ b/menu.js
@@ -207,7 +207,7 @@
             if (optionsOverlay) {
                 optionsAudioToggle.checked = audioEnabled;
                 optionsVolumeSlider.value = menuMusic ? menuMusic.volume * 100 : 100;
-                languageSelect.value = localStorage.getItem('gameLanguage') || 'it';
+                languageSelect.value = LanguageManager.current;
                 optionsOverlay.style.display = 'flex';
             }
         });
@@ -219,7 +219,7 @@
             if (menuMusic) {
                 menuMusic.volume = (audioEnabled ? optionsVolumeSlider.value : 0) / 100;
             }
-            localStorage.setItem('gameLanguage', languageSelect.value);
+            LanguageManager.set(languageSelect.value);
             optionsOverlay.style.display = 'none';
         });
     }

--- a/script.js
+++ b/script.js
@@ -73,6 +73,10 @@ const interactionButtons = [vaiButton, usaButton, guardaButton, prendiButton, pa
   const mapOverlay = document.getElementById('mapOverlay');
   const mapGrid = document.getElementById('mapGrid');
   const closeMapBtn = document.getElementById('closeMapBtn');
+  const mapPreview = document.getElementById('mapPreview');
+  const previewImage = document.getElementById('previewImage');
+  const previewName = document.getElementById('previewName');
+  const goHereBtn = document.getElementById('goHereBtn');
 
   let audioEnabled = true;
   let volumeLevel = 1.0;
@@ -980,6 +984,9 @@ const interactionButtons = [vaiButton, usaButton, guardaButton, prendiButton, pa
   function updateMapOverlay() {
     if (!mapGrid) return;
     mapGrid.innerHTML = '';
+    if (previewImage) previewImage.style.display = 'none';
+    if (goHereBtn) goHereBtn.style.display = 'none';
+    if (previewName) previewName.textContent = '';
     const letters = 'ABCDEFGHIJKLMNOPQRST'.split('');
     for (let r = 0; r <= 20; r++) {
       for (let c = 0; c <= 20; c++) {
@@ -1009,9 +1016,22 @@ const interactionButtons = [vaiButton, usaButton, guardaButton, prendiButton, pa
               name.textContent = data?.name || locId;
               cell.appendChild(name);
               cell.addEventListener('click', () => {
-                if (window.LocationManager) {
-                  window.LocationManager.changeLocation(locId);
-                  mapOverlay.style.display = 'none';
+                const info = window.LocationManager?.locations[locId]?.locationInfo;
+                if (info) {
+                  if (previewImage) {
+                    previewImage.src = info.image || '';
+                    previewImage.style.display = info.image ? 'block' : 'none';
+                  }
+                  if (previewName) previewName.textContent = info.name || locId;
+                  if (goHereBtn) {
+                    goHereBtn.style.display = 'block';
+                    goHereBtn.onclick = () => {
+                      if (window.LocationManager) {
+                        window.LocationManager.changeLocation(locId);
+                        mapOverlay.style.display = 'none';
+                      }
+                    };
+                  }
                 }
               });
             } else {
@@ -1056,7 +1076,7 @@ const interactionButtons = [vaiButton, usaButton, guardaButton, prendiButton, pa
       if (optionsOverlay) {
         optionsAudioToggle.checked = audioEnabled;
         optionsVolumeSlider.value = volumeSlider.value;
-        languageSelect.value = localStorage.getItem('gameLanguage') || 'it';
+        languageSelect.value = LanguageManager.current;
         optionsOverlay.style.display = 'flex';
       }
     });
@@ -1085,7 +1105,7 @@ const interactionButtons = [vaiButton, usaButton, guardaButton, prendiButton, pa
       audioEnabled = optionsAudioToggle.checked;
       volumeSlider.value = optionsVolumeSlider.value;
       updateAudioUI();
-      localStorage.setItem('gameLanguage', languageSelect.value);
+      LanguageManager.set(languageSelect.value);
       optionsOverlay.style.display = 'none';
     });
   }
@@ -1132,6 +1152,9 @@ const interactionButtons = [vaiButton, usaButton, guardaButton, prendiButton, pa
   if (mapBtn && mapOverlay) {
     mapBtn.addEventListener('click', () => {
       updateMapOverlay();
+      if (previewImage) previewImage.style.display = 'none';
+      if (goHereBtn) goHereBtn.style.display = 'none';
+      if (previewName) previewName.textContent = '';
       mapOverlay.style.display = 'flex';
     });
   }

--- a/styles.css
+++ b/styles.css
@@ -1300,4 +1300,37 @@ button:not(.selected):not(.left-button):not(.inventory-button):not(.dialogue-opt
   text-align: center;
 }
 
+/* ===== MAP PREVIEW ===== */
+.map-content {
+  display: flex;
+  width: 100%;
+  flex: 1;
+}
+
+.map-preview {
+  width: 220px;
+  padding-left: 1vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.map-preview img {
+  width: 200px;
+  height: 200px;
+  object-fit: cover;
+  border: 1px solid #00ffff;
+  margin-bottom: 1vh;
+}
+
+.language-select {
+  padding: 1vh;
+  font-size: 2vh;
+  border: 2px solid #00ffff;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.8);
+  color: #ffffff;
+}
+
 

--- a/translations.js
+++ b/translations.js
@@ -1,0 +1,77 @@
+const Translations = {
+  it: {
+    new_game: 'Nuova Partita',
+    load_game: 'Carica Partita',
+    options: 'Opzioni',
+    credits: 'Credits',
+    quit_game: 'Esci dal Gioco',
+    back: 'Indietro',
+    start: 'Avvia',
+    cancel: 'Annulla',
+    save_name: 'Nome salvataggio',
+    audio: 'AUDIO',
+    language: 'LINGUA',
+    close: 'CHIUDI',
+    ok: 'OK',
+    main_menu: 'MENU PRINCIPALE',
+    map_title: 'MAPPA',
+    go_here: 'VAI QUI',
+    welcome_msg: "Benvenuto! Seleziona un'azione per iniziare l'avventura.",
+    inventory_title: 'Inventario',
+    poi_title: 'Punti di interesse',
+    quests_title: 'QUESTS',
+    achievements_title: 'ACHIEVEMENTS',
+    journal_title: 'JOURNAL'
+  },
+  en: {
+    new_game: 'New Game',
+    load_game: 'Load Game',
+    options: 'Options',
+    credits: 'Credits',
+    quit_game: 'Quit Game',
+    back: 'Back',
+    start: 'Start',
+    cancel: 'Cancel',
+    save_name: 'Save Name',
+    audio: 'AUDIO',
+    language: 'LANGUAGE',
+    close: 'CLOSE',
+    ok: 'OK',
+    main_menu: 'MAIN MENU',
+    map_title: 'MAP',
+    go_here: 'GO HERE',
+    welcome_msg: 'Welcome! Select an action to start your adventure.',
+    inventory_title: 'Inventory',
+    poi_title: 'Points of interest',
+    quests_title: 'QUESTS',
+    achievements_title: 'ACHIEVEMENTS',
+    journal_title: 'JOURNAL'
+  }
+};
+
+const LanguageManager = {
+  current: localStorage.getItem('gameLanguage') || 'it',
+  apply() {
+    const lang = this.current;
+    document.documentElement.lang = lang;
+    document.querySelectorAll('[data-i18n]').forEach(el => {
+      const key = el.getAttribute('data-i18n');
+      const txt = Translations[lang][key];
+      if (txt) el.textContent = txt;
+    });
+    document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+      const key = el.getAttribute('data-i18n-placeholder');
+      const txt = Translations[lang][key];
+      if (txt) el.placeholder = txt;
+    });
+  },
+  set(lang) {
+    this.current = lang;
+    localStorage.setItem('gameLanguage', lang);
+    this.apply();
+  }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  LanguageManager.apply();
+});


### PR DESCRIPTION
## Summary
- enlarge map overlay with a preview area
- add language dropdown styling and translation system
- persist selected language and update UI on change

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6851157d27a08326a5302fa8978d13b7